### PR TITLE
[EE4J_8]: javax.rmi package should be exported

### DIFF
--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -58,7 +58,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package>org.omg.*; version=1, com.sun.*;version=1, javax.rmi.CORBA;version=1</Export-Package>
+                        <Export-Package>org.omg.*; version=1, com.sun.*;version=1, javax.rmi;version=1, javax.rmi.CORBA;version=1</Export-Package>
                         <Import-Package>!org.omg.PortableServer.ServantLocatorPackage</Import-Package>
                         <Fragment-Host>system.bundle; extension:=framework</Fragment-Host>
                     </instructions>


### PR DESCRIPTION
Fixes #31 in EE4J_8 branch

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>