### PR TITLE
Continue development after release

### DIFF
--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.2.1-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>


### PR DESCRIPTION
The initial Eclipse (4.2.0) release was done from a branch created for that purpose, EE4J_8. This pull request merges that branch back to master, and updates the pom versions to the new snapshot version, in order to prepare for development of the next release.