### PR TITLE
Manage m-compiler-p as plugin, not dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,11 +99,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-            </dependency>
-            <dependency>
                 <groupId>com.meterware.simplestub</groupId>
                 <artifactId>simplestub</artifactId>
                 <version>1.2.12</version>
@@ -285,6 +280,11 @@
                      <artifactId>maven-javadoc-plugin</artifactId>
                      <version>3.0.1</version>
                 </plugin>  
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.7.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
Fixes #70

Original [commit 69e4c712](https://github.com/javaee/glassfish-corba/commit/69e4c712) reveals that intention.