### PR TITLE
use SSL to request FVD from secure connections

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/folb/ClientGroupManager.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/folb/ClientGroupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -8,71 +8,59 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-//
-// Created       : 2005 Jun 07 (Tue) 13:04:09 by Harold Carr.
-// Last Modified : 2005 Oct 03 (Mon) 15:09:46 by Harold Carr.
-//
-
 package com.sun.corba.ee.impl.folb;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.rmi.PortableRemoteObject;
 
-import org.omg.CORBA.Any;
-import org.omg.CORBA.BAD_PARAM;
-import org.omg.CORBA.ORBPackage.InvalidName;
-import org.omg.IOP.Codec;
-import org.omg.IOP.CodecPackage.FormatMismatch;
-import org.omg.IOP.CodecPackage.TypeMismatch;
-import org.omg.IOP.CodecFactory;
-import org.omg.IOP.CodecFactoryHelper;
-import org.omg.IOP.CodecFactoryPackage.UnknownEncoding;
-import org.omg.IOP.Encoding;
-import org.omg.IOP.ServiceContext;
-import org.omg.PortableInterceptor.ClientRequestInterceptor;
-import org.omg.PortableInterceptor.ClientRequestInfo;
-import org.omg.PortableInterceptor.ForwardRequest;
-import org.omg.PortableInterceptor.ForwardRequestHelper;
-import org.omg.PortableInterceptor.ORBInitializer;
-import org.omg.PortableInterceptor.ORBInitInfo;
-
+import com.sun.corba.ee.impl.interceptors.ClientRequestInfoImpl;
 import com.sun.corba.ee.spi.folb.ClusterInstanceInfo;
 import com.sun.corba.ee.spi.folb.GroupInfoService;
 import com.sun.corba.ee.spi.folb.GroupInfoServiceObserver;
-
 import com.sun.corba.ee.spi.ior.IOR;
-import com.sun.corba.ee.spi.ior.iiop.IIOPProfileTemplate ;
-import com.sun.corba.ee.spi.orb.DataCollector ;
+import com.sun.corba.ee.spi.ior.iiop.AlternateIIOPAddressComponent;
+import com.sun.corba.ee.spi.ior.iiop.ClusterInstanceInfoComponent;
+import com.sun.corba.ee.spi.ior.iiop.IIOPProfileTemplate;
+import com.sun.corba.ee.spi.logging.ORBUtilSystemException;
+import com.sun.corba.ee.spi.misc.ORBConstants;
+import com.sun.corba.ee.spi.orb.DataCollector;
 import com.sun.corba.ee.spi.orb.ORB;
-import com.sun.corba.ee.spi.orb.ORBConfigurator ;
+import com.sun.corba.ee.spi.orb.ORBConfigurator;
+import com.sun.corba.ee.spi.trace.Folb;
+import com.sun.corba.ee.spi.transport.ContactInfo;
 import com.sun.corba.ee.spi.transport.IIOPPrimaryToContactInfo;
 import com.sun.corba.ee.spi.transport.IORToSocketInfo;
 import com.sun.corba.ee.spi.transport.SocketInfo;
-import com.sun.corba.ee.spi.transport.ContactInfo;
-
-import com.sun.corba.ee.impl.interceptors.ClientRequestInfoImpl;
-import com.sun.corba.ee.spi.logging.ORBUtilSystemException;
-import com.sun.corba.ee.spi.misc.ORBConstants;
+import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.BAD_PARAM;
+import org.omg.CORBA.ORBPackage.InvalidName;
+import org.omg.CosNaming.NameComponent;
+import org.omg.CosNaming.NamingContext;
+import org.omg.CosNaming.NamingContextHelper;
+import org.omg.IOP.Codec;
+import org.omg.IOP.CodecFactory;
+import org.omg.IOP.CodecFactoryHelper;
+import org.omg.IOP.CodecFactoryPackage.UnknownEncoding;
+import org.omg.IOP.CodecPackage.FormatMismatch;
+import org.omg.IOP.CodecPackage.TypeMismatch;
+import org.omg.IOP.Encoding;
+import org.omg.IOP.ServiceContext;
+import org.omg.PortableInterceptor.ClientRequestInfo;
+import org.omg.PortableInterceptor.ClientRequestInterceptor;
+import org.omg.PortableInterceptor.ForwardRequest;
+import org.omg.PortableInterceptor.ForwardRequestHelper;
+import org.omg.PortableInterceptor.ORBInitInfo;
+import org.omg.PortableInterceptor.ORBInitializer;
 
 // BEGIN imports for IIOPPrimaryToContactInfo
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 // END imports for IIOPPrimaryToContactInfo
-
 // BEGIN import for IORToSocketInfo
-import java.util.ArrayList;
-import com.sun.corba.ee.spi.ior.iiop.AlternateIIOPAddressComponent;
-import com.sun.corba.ee.spi.ior.iiop.ClusterInstanceInfoComponent;
-import com.sun.corba.ee.spi.ior.iiop.IIOPAddress;
-import com.sun.corba.ee.spi.trace.Folb;
-
-import org.omg.CosNaming.NamingContext ;
-import org.omg.CosNaming.NamingContextHelper ;
-import org.omg.CosNaming.NameComponent ;
-
-import javax.rmi.PortableRemoteObject ;
-import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
 
 
 // END import for IORToSocketInfo
@@ -189,22 +177,14 @@ public class ClientGroupManager
                 return previous;
             }
 
-            List result = new ArrayList();
+            List<SocketInfo> result = new ArrayList<>();
 
             //
             // IIOPProfile Primary address
             //
 
-            IIOPProfileTemplate iiopProfileTemplate = (IIOPProfileTemplate)
-                ior.getProfile().getTaggedProfileTemplate();
-            IIOPAddress primary = iiopProfileTemplate.getPrimaryAddress() ;
-            String host = primary.getHost().toLowerCase();
-            int port = primary.getPort();
-            
-            SocketInfo primarySocketInfo = 
-                createSocketInfo("primary", 
-                                 SocketInfo.IIOP_CLEAR_TEXT, host, port);
-            result.add(primarySocketInfo);
+            IIOPProfileTemplate iiopProfileTemplate = (IIOPProfileTemplate) ior.getProfile().getTaggedProfileTemplate();
+            result.add(iiopProfileTemplate.getPrimarySocketInfo());
 
             //
             // List alternate cluster addresses
@@ -238,11 +218,10 @@ public class ClientGroupManager
                     AlternateIIOPAddressComponent.class );
 
             while (aiterator.hasNext()) {
-                AlternateIIOPAddressComponent alternate = 
-                    aiterator.next();
+                AlternateIIOPAddressComponent alternate = aiterator.next();
                 
-                host = alternate.getAddress().getHost().toLowerCase();
-                port = alternate.getAddress().getPort();
+                String host = alternate.getAddress().getHost().toLowerCase();
+                int port = alternate.getAddress().getPort();
                 
                 result.add(createSocketInfo(
                     "AlternateIIOPAddressComponent",

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/ContactInfoListImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/ContactInfoListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -319,18 +319,11 @@ public class ContactInfoListImpl implements ContactInfoList {
         final boolean isLocal = iiopProfile.isLocal() ;
 
         if (effectiveTargetIORContactInfoList == null) {
-            effectiveTargetIORContactInfoList = 
-                new ArrayList<ContactInfo>();
+            effectiveTargetIORContactInfoList = new ArrayList<>();
 
-            String hostname = 
-                ((IIOPProfileTemplate)iiopProfile.getTaggedProfileTemplate())
-                    .getPrimaryAddress().getHost().toLowerCase();
-            int    port     = 
-                ((IIOPProfileTemplate)iiopProfile.getTaggedProfileTemplate())
-                    .getPrimaryAddress().getPort();
-            // For use by "sticky manager" if one is registered.
-            primaryContactInfo = 
-                createContactInfo(SocketInfo.IIOP_CLEAR_TEXT, hostname, port);
+            IIOPProfileTemplate taggedProfileTemplate = (IIOPProfileTemplate) iiopProfile.getTaggedProfileTemplate();
+            SocketInfo socketInfo = taggedProfileTemplate.getPrimarySocketInfo();
+            primaryContactInfo = createContactInfo(socketInfo.getType(), socketInfo.getHost(), socketInfo.getPort());
 
             if (isLocal) {
                 // NOTE: IMPORTANT:

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/ior/iiop/IIOPProfileTemplate.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/ior/iiop/IIOPProfileTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,13 +10,11 @@
 
 package com.sun.corba.ee.spi.ior.iiop;
 
-import com.sun.corba.ee.spi.ior.TaggedProfileTemplate ;
-
-import com.sun.corba.ee.spi.ior.iiop.GIOPVersion ;
-
-import org.glassfish.gmbal.ManagedData ;
-import org.glassfish.gmbal.ManagedAttribute ;
-import org.glassfish.gmbal.Description ;
+import com.sun.corba.ee.spi.ior.TaggedProfileTemplate;
+import com.sun.corba.ee.spi.transport.SocketInfo;
+import org.glassfish.gmbal.Description;
+import org.glassfish.gmbal.ManagedAttribute;
+import org.glassfish.gmbal.ManagedData;
 
 /**
  * IIOPProfileTemplate represents the parts of an IIOPProfile that are independent
@@ -41,4 +39,11 @@ public interface IIOPProfileTemplate extends TaggedProfileTemplate
     @ManagedAttribute
     @Description( "The host and port of the IP address for the primary endpoint of this profile" )
     public IIOPAddress getPrimaryAddress()  ;
+
+    /**
+     * Returns the description of a socket to create to access the associated endpoint. It's host and port
+     * will match the primary address
+     * @return a description of a socket.
+     */
+    SocketInfo getPrimarySocketInfo();
 }

--- a/orbmain/src/test/java/com/sun/corba/ee/impl/ior/iiop/IIOPProfileTemplateImplTest.java
+++ b/orbmain/src/test/java/com/sun/corba/ee/impl/ior/iiop/IIOPProfileTemplateImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.corba.ee.impl.ior.iiop;
+
+import com.sun.corba.ee.spi.ior.iiop.GIOPVersion;
+import com.sun.corba.ee.spi.ior.iiop.IIOPAddress;
+import com.sun.corba.ee.spi.ior.iiop.IIOPProfileTemplate;
+import com.sun.corba.ee.spi.orb.ORB;
+import com.sun.corba.ee.spi.transport.SocketInfo;
+import org.junit.Test;
+
+import static com.meterware.simplestub.Stub.createStrictStub;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IIOPProfileTemplateImplTest {
+  private static final String HOST = "testhost";
+  private static final int PORT = 1234;
+
+  private ORB orb = createStrictStub(ORB.class);
+  private GIOPVersion version = new GIOPVersion(1, 2);
+  private IIOPAddress primary = new IIOPAddressImpl(HOST, PORT);
+  private IIOPProfileTemplate impl = new IIOPProfileTemplateImpl(orb, version, primary);
+
+  @Test
+  public void socketHostAndAddress_matchPrimaryAddress() {
+    assertThat(impl.getPrimarySocketInfo().getHost(), equalTo(HOST));
+    assertThat(impl.getPrimarySocketInfo().getPort(), equalTo(PORT));
+  }
+
+  @Test
+  public void whenNoTaggedComponents_socketTypeIsPlainText() {
+    assertThat(impl.getPrimarySocketInfo().getType(), equalTo(SocketInfo.IIOP_CLEAR_TEXT));
+  }
+
+  @Test
+  public void whenContainsHttpJavaCodebaseComponent_socketTypeIsPlainText() {
+    addJavaCodebase("http://localhost:1401/base");
+
+    assertThat(impl.getPrimarySocketInfo().getType(), equalTo(SocketInfo.IIOP_CLEAR_TEXT));
+  }
+
+  @Test
+  public void whenContainsHttpsJavaCodebaseComponent_socketTypeIsSsl() {
+    addJavaCodebase("https://localhost:1402/base");
+
+    assertThat(impl.getPrimarySocketInfo().getType(), equalTo(SocketInfo.SSL_PREFIX));
+  }
+
+  private void addJavaCodebase(String urls) {
+    impl.add(new JavaCodebaseComponentImpl(urls));
+  }
+}


### PR DESCRIPTION
Issue #76

When a receiving ORB detects that a received repository ID differs from the one it has computed for the received class, it requests a full-value-description (FVD) from the sender. It turns out, though, that the code was always sending the request in plaintext, even over secure connections. This change causes the request to be made over SSL when warranted.