### PR TITLE
ArrayIndexOutOfBoundsException thrown from org.glassfish.rmic.tools.j…

### DIFF
--- a/rmic/src/main/java/org/glassfish/rmic/tools/java/ClassPath.java
+++ b/rmic/src/main/java/org/glassfish/rmic/tools/java/ClassPath.java
@@ -89,7 +89,7 @@ class ClassPath {
             n++; i++;
         }
         // Build the class path
-        ClassPathEntry[] path = new ClassPathEntry[n+1];
+        ClassPathEntry[] path = new ClassPathEntry[n+2];
 
         int len = pathstr.length();
         for (i = n = 0; i < len; i = j + 1) {

--- a/rmic/src/test/java/org/glassfish/rmic/tools/java/ClassPathTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/tools/java/ClassPathTest.java
@@ -1,0 +1,17 @@
+package org.glassfish.rmic.tools.java;
+
+import java.io.File;
+
+import org.junit.Test;
+
+public class ClassPathTest {
+
+    @Test
+    public void init() {
+        final String classPathString = "abc" + File.pathSeparator + "def";
+
+        // this should not throw an exception
+        new ClassPath(classPathString);
+    }
+
+}


### PR DESCRIPTION
…ava.ClassPath. Allow room for a jrt:/ entry to be added to the class path array and provide a test that proofs the problem.