### PR TITLE
Tests fail in windows environment due to File.separatorChar

### DIFF
--- a/idlj/src/test/java/com/sun/tools/corba/ee/idl/toJavaPortable/TestUtils.java
+++ b/idlj/src/test/java/com/sun/tools/corba/ee/idl/toJavaPortable/TestUtils.java
@@ -19,8 +19,6 @@
 
 package com.sun.tools.corba.ee.idl.toJavaPortable;
 
-import java.io.File;
-
 public class TestUtils {
     @SuppressWarnings("ConstantConditions")
     public static String getClassPathString() {
@@ -30,6 +28,6 @@ public class TestUtils {
     }
 
     private static String toPath(String className) {
-        return className.replace('.', File.separatorChar) + ".class";
+        return className.replace('.', '/') + ".class";
     }
 }

--- a/rmic/src/test/java/org/glassfish/rmic/TestUtils.java
+++ b/rmic/src/test/java/org/glassfish/rmic/TestUtils.java
@@ -57,6 +57,6 @@ public class TestUtils {
     }
 
     private static String toPath(String className) {
-        return className.replace('.', File.separatorChar) + ".class";
+        return className.replace('.', '/') + ".class";
     }
 }

--- a/rmic/src/test/java/org/glassfish/rmic/tools/java/ClassDefinitionFactoryTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/tools/java/ClassDefinitionFactoryTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 import javax.rmi.PortableRemoteObject;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.AccessibleObject;
@@ -93,7 +92,7 @@ public abstract class ClassDefinitionFactoryTest {
     }
 
     private String toPath(Class<?> aClass) {
-        return aClass.getName().replace('.', File.separatorChar) + ".class";
+        return aClass.getName().replace('.', '/') + ".class";
     }
 
     private void loadNested(ClassDefinition classDefinition) {


### PR DESCRIPTION
Tests throw `StringIndexOutOfBounds` error when checking `indexOf("/target/")`.