### PR TITLE
Tests to show that de/serialization of ConcurrentHashMap fails

### DIFF
--- a/functional-tests/src/test/java/javax/rmi/CORBA/serialization/SerializationTest.java
+++ b/functional-tests/src/test/java/javax/rmi/CORBA/serialization/SerializationTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  * Copyright (c) 1998-1999 IBM Corp. All rights reserved.
  *
@@ -34,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Properties;
+import java.util.HashMap;
 import java.util.Vector;
 import org.glassfish.pfl.test.JUnitReportHelper;
 import rmic.ObjectByValue;
@@ -395,6 +397,10 @@ public class SerializationTest extends test.Test
             ComplexTestObjectXXX xxx = new ComplexTestObjectXXX();
             sos.write_value(xxx);
 
+            test( "writeHashMap" );
+            HashMap hmap = new HashMap();
+            sos.write_value(hmap);
+
             //System.out.println("offset = " + ((com.sun.corba.ee.impl.encoding.CDROutputStream)sos).get_offset());
             //System.out.println("countit = " + ((com.sun.corba.ee.impl.encoding.CDROutputStream)sos).countit);
 
@@ -733,6 +739,11 @@ public class SerializationTest extends test.Test
             ComplexTestObjectXXX _xxx = (ComplexTestObjectXXX)sis.read_value();
             if (!_xxx.equals(xxx))
                 throw new Error("Any test using xxx failed!");
+
+            test( "readHashMap" );
+            HashMap _hmap = (HashMap)sis.read_value();
+            if (!_hmap.equals(hmap))
+                throw new Error("HashMap test using hmap failed!");
         } catch (Throwable e) {
             helper.fail( e ) ;
             status = new Error(e.getMessage());

--- a/functional-tests/src/test/java/javax/rmi/CORBA/serialization/SerializationTest.java
+++ b/functional-tests/src/test/java/javax/rmi/CORBA/serialization/SerializationTest.java
@@ -36,6 +36,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Properties;
 import java.util.HashMap;
+import java.util.Random;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import org.glassfish.pfl.test.JUnitReportHelper;
@@ -398,6 +399,10 @@ public class SerializationTest extends test.Test
             ComplexTestObjectXXX xxx = new ComplexTestObjectXXX();
             sos.write_value(xxx);
 
+            test( "writeRandom" );
+            Random random = new Random();
+            sos.write_value(random);
+
             test( "writeHashMap" );
             HashMap hmap = new HashMap();
             sos.write_value(hmap);
@@ -744,6 +749,11 @@ public class SerializationTest extends test.Test
             ComplexTestObjectXXX _xxx = (ComplexTestObjectXXX)sis.read_value();
             if (!_xxx.equals(xxx))
                 throw new Error("Any test using xxx failed!");
+
+            test( "readRandom" );
+            Random _random = (Random)sis.read_value();
+            if (_random == null)
+                throw new Error("Random test using random failed!");
 
             test( "readHashMap" );
             HashMap _hmap = (HashMap)sis.read_value();

--- a/functional-tests/src/test/java/javax/rmi/CORBA/serialization/SerializationTest.java
+++ b/functional-tests/src/test/java/javax/rmi/CORBA/serialization/SerializationTest.java
@@ -37,6 +37,7 @@ import java.io.ObjectOutputStream;
 import java.util.Properties;
 import java.util.HashMap;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 import org.glassfish.pfl.test.JUnitReportHelper;
 import rmic.ObjectByValue;
 import org.omg.CORBA.WStringValueHelper;
@@ -401,6 +402,10 @@ public class SerializationTest extends test.Test
             HashMap hmap = new HashMap();
             sos.write_value(hmap);
 
+            test( "writeConcurrentHashMap" );
+            ConcurrentHashMap chmap = new ConcurrentHashMap();
+            sos.write_value(chmap);
+
             //System.out.println("offset = " + ((com.sun.corba.ee.impl.encoding.CDROutputStream)sos).get_offset());
             //System.out.println("countit = " + ((com.sun.corba.ee.impl.encoding.CDROutputStream)sos).countit);
 
@@ -744,6 +749,11 @@ public class SerializationTest extends test.Test
             HashMap _hmap = (HashMap)sis.read_value();
             if (!_hmap.equals(hmap))
                 throw new Error("HashMap test using hmap failed!");
+
+            test( "readConcurrentHashMap" );
+            ConcurrentHashMap _chmap = (ConcurrentHashMap)sis.read_value();
+            if (!_chmap.equals(chmap))
+                throw new Error("ConcurrentHashMap test using chmap failed!");
         } catch (Throwable e) {
             helper.fail( e ) ;
             status = new Error(e.getMessage());


### PR DESCRIPTION
This results in
```xml
  <testcase classname="javax.rmi.CORBA.serialization.SerializationTest" name="readRandom" time="0.0" />
  <testcase classname="javax.rmi.CORBA.serialization.SerializationTest" name="readHashMap" time="0.001" />
  <testcase classname="javax.rmi.CORBA.serialization.SerializationTest" name="readConcurrentHashMap" time="0.01">
    <error message="WARNING: 00810011: Exception from readValue on ValueHandler in CDRInputStream" type="org.omg.CORBA.MARSHAL">org.omg.CORBA.MARSHAL: WARNING: 00810011: Exception from readValue on ValueHandler in CDRInputStream  vmcid: OMG  minor code: 11 completed: Maybe
	at com.sun.proxy.$Proxy3.valuehandlerReadException(Unknown Source)
	at com.sun.corba.ee.impl.encoding.CDRInputStream_1_0.readRMIIIOPValueType(CDRInputStream_1_0.java:797)
	at com.sun.corba.ee.impl.encoding.CDRInputStream_1_0.read_value(CDRInputStream_1_0.java:892)
	at com.sun.corba.ee.impl.encoding.CDRInputObject.read_value(CDRInputObject.java:497)
	at com.sun.corba.ee.impl.io.IIOPInputStream.inputObjectField(IIOPInputStream.java:2085)
	at com.sun.corba.ee.impl.io.IIOPInputStream.inputClassFields(IIOPInputStream.java:2327)
	at com.sun.corba.ee.impl.io.IIOPInputStream.defaultReadObjectDelegate(IIOPInputStream.java:493)
	at com.sun.corba.ee.impl.io.InputStreamHook.defaultReadObject(InputStreamHook.java:205)
	at java.util.concurrent.ConcurrentHashMap.readObject(ConcurrentHashMap.java:1438)
	at com.sun.corba.ee.impl.io.IIOPInputStream.invokeObjectReader(IIOPInputStream.java:1758)
	at com.sun.corba.ee.impl.io.IIOPInputStream.inputObject(IIOPInputStream.java:1112)
	at com.sun.corba.ee.impl.io.IIOPInputStream.simpleReadObject(IIOPInputStream.java:322)
	at com.sun.corba.ee.impl.io.ValueHandlerImpl.readValueInternal(ValueHandlerImpl.java:283)
	at com.sun.corba.ee.impl.io.ValueHandlerImpl.readValue(ValueHandlerImpl.java:249)
	at com.sun.corba.ee.impl.encoding.CDRInputStream_1_0.readRMIIIOPValueType(CDRInputStream_1_0.java:790)
	at com.sun.corba.ee.impl.encoding.CDRInputStream_1_0.read_value(CDRInputStream_1_0.java:892)
	at com.sun.corba.ee.impl.encoding.CDRInputStream_1_0.read_value(CDRInputStream_1_0.java:710)
	at com.sun.corba.ee.impl.encoding.CDRInputObject.read_value(CDRInputObject.java:491)
	at javax.rmi.CORBA.serialization.SerializationTest.run(SerializationTest.java:764)
	at test.Test.runTestClass(Test.java:1110)
	at test.Test.run(Test.java:827)
	at test.Test.runTestFile(Test.java:1017)
	at test.Test.run(Test.java:834)
	at test.Test.main(Test.java:308)
Caused by: java.lang.NullPointerException
	at com.sun.corba.ee.impl.io.IIOPInputStream.inputObject(IIOPInputStream.java:949)
	at com.sun.corba.ee.impl.io.IIOPInputStream.simpleReadObject(IIOPInputStream.java:322)
	at com.sun.corba.ee.impl.io.ValueHandlerImpl.readValueInternal(ValueHandlerImpl.java:283)
	at com.sun.corba.ee.impl.io.ValueHandlerImpl.readValue(ValueHandlerImpl.java:249)
	at com.sun.corba.ee.impl.encoding.CDRInputStream_1_0.readRMIIIOPValueType(CDRInputStream_1_0.java:790)
</error>
  </testcase>
```