### PR TITLE
Remove temporary directories after tests

### DIFF
--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -43,6 +43,11 @@
             <groupId>com.meterware.simplestub</groupId>
             <artifactId>simplestub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/idlj/src/test/java/com/sun/tools/corba/ee/idl/toJavaPortable/IdljGenerationTest.java
+++ b/idlj/src/test/java/com/sun/tools/corba/ee/idl/toJavaPortable/IdljGenerationTest.java
@@ -19,6 +19,8 @@
 
 package com.sun.tools.corba.ee.idl.toJavaPortable;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -45,6 +47,11 @@ public class IdljGenerationTest {
     @BeforeClass
     public static void clearRootDir() throws IOException {
         rootDir = Files.createTempDirectory("idlj").toFile();
+    }
+
+    @AfterClass
+    public static void cleanRootDir() throws IOException {
+        FileUtils.deleteDirectory(rootDir);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
                 <version>1.3</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.9.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -54,6 +54,11 @@
             <groupId>com.meterware.simplestub</groupId>
             <artifactId>simplestub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/rmic/src/test/java/org/glassfish/rmic/MainTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/MainTest.java
@@ -19,9 +19,11 @@
 
 package org.glassfish.rmic;
 
+import org.apache.commons.io.FileUtils;
 import org.glassfish.rmic.classes.hcks.RmiIIServant;
 import org.glassfish.rmic.tools.java.ClassPath;
 import org.glassfish.rmic.tools.java.Identifier;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +49,11 @@ public class MainTest {
         destDir = Files.createTempDirectory("rmic").toFile();
         environment = new BatchEnvironment(out, classPath, destDir);
         environment.flags = F_WARNINGS;
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirectory(destDir);
     }
 
     @Test

--- a/rmic/src/test/java/org/glassfish/rmic/RmicGenerationTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/RmicGenerationTest.java
@@ -40,6 +40,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import org.apache.commons.io.FileUtils;
 import org.glassfish.rmic.classes.covariantReturn.DogFinder;
 import org.glassfish.rmic.classes.errorClasses.InterfaceWithNonRemoteMethod;
 import org.glassfish.rmic.classes.errorClasses.NotRemoteClass;
@@ -56,6 +57,7 @@ import org.glassfish.rmic.classes.primitives.InterfaceWithNonPrimitiveConstant;
 import org.glassfish.rmic.classes.primitives.RmiTestRemoteImpl;
 import org.glassfish.rmic.classes.rmipoacounter.CounterImpl;
 import org.glassfish.rmic.classes.systemexceptions.ServerInvokerServantPOA;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -71,6 +73,11 @@ public class RmicGenerationTest {
     @BeforeClass
     public static void clearRootDir() throws IOException {
         rootDir = Files.createTempDirectory("rmic").toFile();
+    }
+
+    @AfterClass
+    public static void cleanRootDir() throws IOException {
+        FileUtils.deleteDirectory(rootDir);
     }
 
     @Test


### PR DESCRIPTION
After running tests, plenty of directories in `$TMP` directory are left.
I propose to remove them to release resources.

I considered JUnit's `@Rule` for `TemporaryDirectory` but there is something like `BatchEnvironment` still expecting `File`. I didn't want to change that.