### PR TITLE
Synchronize IDLJ version

### DIFF
--- a/idlj/src/main/resources/com/sun/tools/corba/ee/idl/toJavaPortable/toJavaPortable.properties
+++ b/idlj/src/main/resources/com/sun/tools/corba/ee/idl/toJavaPortable/toJavaPortable.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
 # Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 1997-1998 IBM Corp. All rights reserved.
 #
@@ -42,7 +43,7 @@ toJavaProlog2=from %0
 PreEmit.indeterminateTypeInfo=Cannot determine type infomation for %0.
 InterfaceGen.noImpl=No local implementation found for %0.
 Version.product=IDL-to-Java compiler (portable), version "%0"
-Version.number=4.1
+Version.number=4.2
 NameModifier.TooManyPercent=Pattern contains more than one percent characters
 NameModifier.NoPercent=Pattern does not contain a percent character
 NameModifier.InvalidChar=Pattern contains an invalid character %0

--- a/idlj/src/main/resources/com/sun/tools/corba/ee/idl/toJavaPortable/toJavaPortable_ja.properties
+++ b/idlj/src/main/resources/com/sun/tools/corba/ee/idl/toJavaPortable/toJavaPortable_ja.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
 # Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 1997-1998 IBM Corp. All rights reserved.
 #
@@ -47,7 +48,7 @@ InterfaceGen.noImpl=%0 \u306e\u30ed\u30fc\u30ab\u30eb\u5b9f\u88c5\u304c\u898b\u3
 #InterfaceGen.noImpl=No local implementation found for %0.
 Version.product=IDL-to-Java \u30b3\u30f3\u30d1\u30a4\u30e9 (\u30dd\u30fc\u30bf\u30d6\u30eb), \u30d0\u30fc\u30b8\u30e7\u30f3 "%0"
 #Version.product=IDL-to-Java compiler (portable), version "%0"
-Version.number=3.1
+Version.number=4.2
 #Version.number=3.1
 NameModifier.TooManyPercent=\u30d1\u30bf\u30fc\u30f3\u306b\u30011 \u3064\u4ee5\u4e0a\u306e % \u6587\u5b57\u304c\u542b\u307e\u308c\u3066\u3044\u307e\u3059
 #NameModifier.TooManyPercent=Pattern contains more than one percent characters


### PR DESCRIPTION
Currently
```
$ LANG=en_GB.UTF-8 java -jar idlj-4.2.4.jar -i idl idl/orb.idl
$ grep -B2 -A3 "4\\.1" org/omg/CORBA/WStringValueHelper.java
/**
* org/omg/CORBA/WStringValueHelper.java .
* Generated by the IDL-to-Java compiler (portable), version "4.1"
* from idl/orb.idl
* Friday, 2 December 2022 at 11:55:30 Central European Standard Time
*/
```
and for Japanese:
```
$ LANG=ja_JP.UTF-8 java -jar idlj-4.2.4.jar -i idl idl/orb.idl
$ grep -B2 -A3 "3\\.1" org/omg/CORBA/WStringValueHelper.java
/**
* org/omg/CORBA/WStringValueHelper.java .
* IDL-to-Java コンパイラ (ポータブル), バージョン "3.1" で生成
* 生成元: idl/orb.idl
* 2022年12月3日 7時11分33秒 JST
*/
```