### PR TITLE
Bump maven-bundle-plugin from 4.2.1 to 5.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>5.1.1</version>
                     <extensions>true</extensions>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <!--
 
     Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -213,7 +213,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.1</version>
+                    <version>5.1.8</version>
                     <extensions>true</extensions>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.1.0</version>
+                    <version>4.2.1</version>
                     <extensions>true</extensions>
                     <executions>
                         <execution>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -67,7 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
                 <configuration combine.self="override">
                     <archive>
                         <manifest>


### PR DESCRIPTION
Currently, using JDK17 to build causes:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.621 s
[INFO] Finished at: 2022-12-27T22:51:56+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:4.1.0:manifest (default) on project glassfish-corba-omgapi: Execution default of goal org.apache.felix:maven-bundle-plugin:4.1.0:manifest failed.: ConcurrentModificationException -> [Help 1]
```

This change helps with that.
[FELIX-6259](https://issues.apache.org/jira/browse/FELIX-6259)