### PR TITLE
Enhancement: Add Configurable Timeout to Socket Connection Methods

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/misc/ORBUtility.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/misc/ORBUtility.java
@@ -20,6 +20,7 @@
 
 package com.sun.corba.ee.impl.misc;
 
+import java.net.Socket;
 import java.security.AccessController;
 import java.security.PermissionCollection;
 import java.security.Policy;
@@ -72,24 +73,33 @@ import com.sun.corba.ee.spi.logging.OMGSystemException ;
 import com.sun.corba.ee.impl.ior.iiop.JavaSerializationComponent;
 import com.sun.corba.ee.impl.javax.rmi.CORBA.Util;
 
+import static com.sun.corba.ee.spi.misc.ORBConstants.TRANSPORT_TCP_CONNECT_MAX_TIME_TO_WAIT;
+
 /**
  *  Handy class full of static functions that don't belong in util.Utility for pure ORB reasons.
  */
 public final class ORBUtility {
+
+    public static SocketChannel openSocketChannel(SocketAddress sa) throws IOException {
+        return openSocketChannel(sa, TRANSPORT_TCP_CONNECT_MAX_TIME_TO_WAIT);
+    }
+
     /** Utility method for working around leak in SocketChannel.open( SocketAddress )
      * method.
      * @param sa address to connect to
+     * @param timeout – the timeout value to be used in milliseconds.
      * @return The opened channel
      * @throws java.io.IOException If an I/O error occurs
      * @see SocketChannel#connect(java.net.SocketAddress)
      */
-    public static SocketChannel openSocketChannel( SocketAddress sa ) 
+    public static SocketChannel openSocketChannel(SocketAddress sa, int timeout)
         throws IOException {
 
         SocketChannel sc = SocketChannel.open() ;
 
         try {
-            sc.connect( sa ) ;
+            Socket socket = sc.socket();
+            socket.connect(sa, timeout);
             return sc ;
         } catch (RuntimeException | IOException exc ) {
             try {

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/ConnectionImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/ConnectionImpl.java
@@ -225,8 +225,13 @@ public class ConnectionImpl extends EventHandlerBase implements Connection, Work
         this.contactInfo = contactInfo;
 
         try {
+            TcpTimeouts tcpConnectTimeouts = orb.getORBData().getTransportTcpConnectTimeouts();
             defineSocket(useSelectThreadToWait,
-                    orb.getORBData().getSocketFactory().createSocket(socketType, new InetSocketAddress(hostname, port)));
+                    orb.getORBData().getSocketFactory().createSocket(
+                            orb.getORBData().connectionSocketType(),
+                            new InetSocketAddress(hostname, port),
+                            tcpConnectTimeouts.get_max_time_to_wait())
+            );
         } catch (Throwable t) {
             throw wrapper.connectFailure(t, socketType, hostname,
                     Integer.toString(port));

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/DefaultSocketFactoryImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/DefaultSocketFactoryImpl.java
@@ -38,7 +38,7 @@ import com.sun.corba.ee.impl.misc.ORBUtility;
 public class DefaultSocketFactoryImpl
     implements ORBSocketFactory
 {
-    private ORB orb;
+    protected ORB orb;
 
     public void setORB(ORB orb)
     {
@@ -60,27 +60,6 @@ public class DefaultSocketFactoryImpl
         }
         serverSocket.bind(inetSocketAddress);
         return serverSocket;
-    }
-
-    public Socket createSocket(String type, 
-                               InetSocketAddress inetSocketAddress)
-        throws IOException
-    {
-        SocketChannel socketChannel = null;
-        Socket socket = null;
-
-        if (orb.getORBData().connectionSocketType().equals(ORBConstants.SOCKETCHANNEL)) {
-            socketChannel = ORBUtility.openSocketChannel(inetSocketAddress);
-            socket = socketChannel.socket();
-        } else {
-            socket = new Socket(inetSocketAddress.getHostName(),
-                                inetSocketAddress.getPort());
-        }
-
-        // Disable Nagle's algorithm (i.e., always send immediately).
-        socket.setTcpNoDelay(true);
-
-        return socket;
     }
 
     public void setAcceptedSocketOptions(Acceptor acceptor,

--- a/orbmain/src/test/java/com/sun/corba/ee/impl/transport/DefaultSocketFactoryImplTest.java
+++ b/orbmain/src/test/java/com/sun/corba/ee/impl/transport/DefaultSocketFactoryImplTest.java
@@ -1,0 +1,85 @@
+package com.sun.corba.ee.impl.transport;
+
+import com.sun.corba.ee.spi.misc.ORBConstants;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class DefaultSocketFactoryImplTest {
+    private static final String TEST_TYPE = ORBConstants.SOCKETCHANNEL;
+    private static final int TEST_TIMEOUT = 1000;
+
+    @Test
+    public void testCreateSocketWithSocketChannelType() throws IOException {
+        DefaultSocketFactoryImpl sf = new DefaultSocketFactoryImpl();
+        String testMessage = UUID.randomUUID().toString();
+        try (ServerSocket serverSocket = createServerSocket(testMessage)) {
+            final InetSocketAddress address = new InetSocketAddress("localhost", serverSocket.getLocalPort());
+            Socket socket = sf.createSocket(TEST_TYPE, address, TEST_TIMEOUT);
+            assertNotNull(socket);
+            assertTrue(socket.getTcpNoDelay());
+            validateSocket(socket, testMessage);
+        }
+    }
+
+    @Test
+    public void testCreateSocketWithOtherType() throws IOException {
+        DefaultSocketFactoryImpl sf = new DefaultSocketFactoryImpl();
+        String testMessage = UUID.randomUUID().toString();
+        try (ServerSocket serverSocket = createServerSocket(testMessage)) {
+            final InetSocketAddress address = new InetSocketAddress("localhost", serverSocket.getLocalPort());
+            Socket socket = sf.createSocket("otherType", address, TEST_TIMEOUT);
+            assertNotNull(socket);
+            assertTrue(socket.getTcpNoDelay());
+            validateSocket(socket, testMessage);
+        }
+    }
+
+    @Test(expected = SocketTimeoutException.class)
+    public void testCreateSocketWithTimeoutSocketChannelType() throws IOException {
+        DefaultSocketFactoryImpl sf = new DefaultSocketFactoryImpl();
+        InetSocketAddress unreachableAddress = new InetSocketAddress("10.0.0.0", 8080);
+        sf.createSocket(TEST_TYPE, unreachableAddress, TEST_TIMEOUT);
+    }
+
+    @Test(expected = SocketTimeoutException.class)
+    public void testCreateSocketWithTimeoutOtherType() throws IOException {
+        DefaultSocketFactoryImpl sf = new DefaultSocketFactoryImpl();
+        InetSocketAddress unreachableAddress = new InetSocketAddress("10.0.0.0", 8080);
+        sf.createSocket("otherType", unreachableAddress, TEST_TIMEOUT);
+    }
+
+    private ServerSocket createServerSocket(String message) throws IOException {
+        ServerSocket serverSocket = new ServerSocket();
+        serverSocket.bind(null);
+
+        new Thread(() -> {
+            try {
+                Socket clientSocket = serverSocket.accept();
+                OutputStream out = clientSocket.getOutputStream();
+                out.write(message.getBytes());
+                out.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+
+        return serverSocket;
+    }
+
+    private void validateSocket(Socket socket, String expectedMessage) throws IOException {
+        InputStream in = socket.getInputStream();
+        byte[] buffer = new byte[expectedMessage.length()];
+        int read = in.read(buffer);
+        assertEquals(expectedMessage, new String(buffer, 0, read));
+    }
+}

--- a/test/src/share/classes/corba/nortel/NortelSocketFactory.java
+++ b/test/src/share/classes/corba/nortel/NortelSocketFactory.java
@@ -20,6 +20,7 @@
 package corba.nortel ;
 
 import com.sun.corba.ee.impl.transport.DefaultSocketFactoryImpl;
+import com.sun.corba.ee.spi.transport.TcpTimeouts;
 
 import java.io.IOException;
 
@@ -62,13 +63,15 @@ public class NortelSocketFactory extends DefaultSocketFactoryImpl {
         }
 
         Socket socket = null;
+        TcpTimeouts tcpConnectTimeouts = orb.getORBData().getTransportTcpConnectTimeouts();
         if (useNio) {
-            socket = super.createSocket(type, in); 
+            socket = super.createSocket(orb.getORBData().connectionSocketType(), in, tcpConnectTimeouts.get_max_time_to_wait());
         } else {
-            socket = new Socket(in.getHostName(), in.getPort());
-            socket.setTcpNoDelay(true);
+            socket = new Socket();
+            socket.connect(in, tcpConnectTimeouts.get_max_time_to_wait());
         }
-        
+
+        socket.setTcpNoDelay(true);
         savedSocket = socket;
         return socket;
     }


### PR DESCRIPTION
The ORB does not set a timeout when establishing a connection, and in some cases, such as when the opposite endpoint has set up firewall rules or is connecting to a non-existent IP address, the connection process will block for a long time at the native method:

```java
"http-listener-1(3)" #42 daemon prio=5 os_prio=31 cpu=10.88ms elapsed=436.72s tid=0x00007f8218374800 nid=0xec03 runnable  [0x0000700004bd7000]
   java.lang.Thread.State: RUNNABLE
    at sun.nio.ch.Net.connect0(java.base@17.0.7/Native Method)
    at sun.nio.ch.Net.connect(java.base@17.0.7/Net.java:579)
    at sun.nio.ch.Net.connect(java.base@17.0.7/Net.java:586)
    at sun.nio.ch.SocketChannelImpl.connect(java.base@17.0.7/SocketChannelImpl.java:853)
    at com.sun.corba.ee.impl.misc.ORBUtility.openSocketChannel(ORBUtility.java:92)
    at org.glassfish.enterprise.iiop.impl.IIOPSSLSocketFactory.createSocket(IIOPSSLSocketFactory.java:306)
    at com.sun.corba.ee.impl.transport.ConnectionImpl.<init>(ConnectionImpl.java:229)
    at com.sun.corba.ee.impl.transport.ConnectionImpl.<init>(ConnectionImpl.java:254)
    at com.sun.corba.ee.impl.transport.ContactInfoImpl.createConnection(ContactInfoImpl.java:108)
    at com.sun.corba.ee.impl.protocol.ClientRequestDispatcherImpl.beginRequest(ClientRequestDispatcherImpl.java:200)
    ...
```

By using tcpdump to capture packets, it was discovered that the kernel was constantly performing TCP retransmissions, with the number of retransmissions being controlled by the kernel parameter `net.ipv4.tcp_syn_retries` and using an exponential backoff strategy. On my machine, it takes 130 seconds for the timeout to occur.

![tcp retransmissions](https://raw.githubusercontent.com/mz1999/material/master/images202307151938271.png)

Therefore a configurable timeout should be set for the connection process. In fact, ORB already has a configurable property [com.sun.corba.ee.transport.ORBTCPConnectTimeouts](https://github.com/eclipse-ee4j/orb/blob/e94c45b67f9f2e71b1b535d8bced62692955f08a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java#L267), but the connection process does not currently utilize this parameter.

This PR introduces a significant enhancement to the socket connection methods, providing more flexibility and control over socket connections.Additionally I add unit tests to ensure the correct functionality of the updated methods. These tests cover both normal operation and timeout scenarios.