### PR TITLE
Only optionally try to find an even better match when class loading.

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/util/Utility.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/util/Utility.java
@@ -309,7 +309,7 @@ public final class Utility {
                 } else {
                     loadedClass = ORBClassLoader.loadClass(className);
                 }
-            } catch (Exception e) {
+            } catch (ClassNotFoundException e) {
                 wrapper.classNotFound(className);
             }
         }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/util/Utility.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/util/Utility.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998-1999 IBM Corp. All rights reserved.
  * Copyright (c) 2019 Payara Services Ltd.
@@ -302,10 +303,14 @@ public final class Utility {
                     "expected Type.");
             }
 
-            if (expectedTypeClassLoader != null) {
-                loadedClass = expectedTypeClassLoader.loadClass(className);
-            } else {
-                loadedClass = ORBClassLoader.loadClass(className);
+            try {
+                if (expectedTypeClassLoader != null) {
+                    loadedClass = expectedTypeClassLoader.loadClass(className);
+                } else {
+                    loadedClass = ORBClassLoader.loadClass(className);
+                }
+            } catch (Exception e) {
+                wrapper.classNotFound(className);
             }
         }
 


### PR DESCRIPTION
This allows wrapper types (like the one for an Enum) to actually work.

See https://github.com/eclipse-ee4j/glassfish/issues/24558