### PR TITLE
Drop `wagon-webdav-jackrabbit` extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,14 +387,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>2.4</version>
-            </extension>
-        </extensions>
     </build>
 
     <reporting>


### PR DESCRIPTION
This was introduced in b9bd74e8d but then `distributionManagement` was updated in c908761b2, but the extension left there.

Closes #164 