### PR TITLE
Replaced deprecated methods and calls

### DIFF
--- a/functional-tests/src/test/idl/corba/poapolicies/Hello.idl
+++ b/functional-tests/src/test/idl/corba/poapolicies/Hello.idl
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -37,7 +38,7 @@ module Util {
   // invocation path more extensively (example, ones that
   // throw exceptions etc)
 
-  interface Factory {
+  interface ServantFactory {
     Object create(in string intfName, in string implName, in CreationMethods how);
     void overAndOut();
   };

--- a/functional-tests/src/test/java/corba/poapolicies/BasicObjectFactoryImpl.java
+++ b/functional-tests/src/test/java/corba/poapolicies/BasicObjectFactoryImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -20,11 +21,11 @@
 package corba.poapolicies;
 
 import Util.CreationMethods;
-import Util.FactoryPOA;
+import Util.ServantFactoryPOA;
 import org.omg.PortableServer.POA;
 import org.omg.PortableServer.Servant;
 
-public class BasicObjectFactoryImpl extends FactoryPOA 
+public class BasicObjectFactoryImpl extends ServantFactoryPOA
 {
     final boolean useServantToReference = true;
 

--- a/functional-tests/src/test/java/corba/poapolicies/HelloClient.java
+++ b/functional-tests/src/test/java/corba/poapolicies/HelloClient.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -22,10 +23,10 @@ package corba.poapolicies;
 import HelloStuff.Hello;
 import HelloStuff.HelloHelper;
 import Util.CreationMethods;
-import Util.Factory;
+import Util.ServantFactory;
 
 public class HelloClient {
-    public static Hello createHello(CreationMethods c, Factory f) {
+    public static Hello createHello(CreationMethods c, ServantFactory f) {
         System.out.println("createHello");
         String id = HelloHelper.id();
         System.out.println("id: " + id);
@@ -60,7 +61,7 @@ public class HelloClient {
             System.out.println("Client starting");
 
             Utility u = new Utility(args);
-            Factory f = u.readFactory();
+            ServantFactory f = u.readFactory();
 
             System.out.println("readFactory");
             

--- a/functional-tests/src/test/java/corba/poapolicies/HelloServer.java
+++ b/functional-tests/src/test/java/corba/poapolicies/HelloServer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -19,7 +20,7 @@
 
 package corba.poapolicies;
 
-import Util.FactoryHelper;
+import Util.ServantFactoryHelper;
 import org.omg.PortableServer.POA;
 
 class Waiter extends Thread {
@@ -82,7 +83,7 @@ public class HelloServer
             
             byte[] id = thePOA.activate_object(theFactory);
             
-            u.writeFactory(FactoryHelper.narrow(thePOA.servant_to_reference(theFactory)));          
+            u.writeFactory(ServantFactoryHelper.narrow(thePOA.servant_to_reference(theFactory)));
             
             thePOA.the_POAManager().activate();
 

--- a/functional-tests/src/test/java/corba/poapolicies/Utility.java
+++ b/functional-tests/src/test/java/corba/poapolicies/Utility.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -76,12 +77,12 @@ public class Utility {
         return null;
     }
 
-    public void writeFactory(Util.Factory ref) {
-        writeObjref(ref, "Factory");
+    public void writeFactory(Util.ServantFactory ref) {
+        writeObjref(ref, "ServantFactory");
     }
 
-    public Util.Factory readFactory() {
-        return Util.FactoryHelper.narrow(readObjref("Factory"));
+    public Util.ServantFactory readFactory() {
+        return Util.ServantFactoryHelper.narrow(readObjref("ServantFactory"));
     }
 }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/presentation/rmi/codegen/CodegenProxyCreator.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/presentation/rmi/codegen/CodegenProxyCreator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +19,20 @@
  */
 
 package com.sun.corba.ee.impl.presentation.rmi.codegen;
+
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.glassfish.pfl.basic.contain.Pair;
+import org.glassfish.pfl.dynamic.codegen.spi.Expression;
+import org.glassfish.pfl.dynamic.codegen.spi.MethodInfo;
+import org.glassfish.pfl.dynamic.codegen.spi.Primitives;
+import org.glassfish.pfl.dynamic.codegen.spi.Type;
+import org.glassfish.pfl.dynamic.codegen.spi.Utility;
+import org.glassfish.pfl.dynamic.codegen.spi.Variable;
 
 import static java.lang.reflect.Modifier.ABSTRACT;
 import static java.lang.reflect.Modifier.PRIVATE;
@@ -48,27 +63,13 @@ import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._this;
 import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._void;
 import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper.splitClassName;
 
-import java.io.PrintStream;
-import java.lang.reflect.Method;
-import java.security.ProtectionDomain;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import org.glassfish.pfl.basic.contain.Pair;
-import org.glassfish.pfl.dynamic.codegen.spi.Expression;
-import org.glassfish.pfl.dynamic.codegen.spi.MethodInfo;
-import org.glassfish.pfl.dynamic.codegen.spi.Primitives;
-import org.glassfish.pfl.dynamic.codegen.spi.Type;
-import org.glassfish.pfl.dynamic.codegen.spi.Utility;
-import org.glassfish.pfl.dynamic.codegen.spi.Variable;
-
-/** Generate a proxy with a specified base class.  
+/** Generate a proxy with a specified base class.
  */
 public class CodegenProxyCreator {
-    private String className ;
-    private Type superClass ;
-    private List<Type> interfaces ;
-    private List<MethodInfo> methods ;
+    private final String className ;
+    private final Type superClass ;
+    private final List<Type> interfaces ;
+    private final List<MethodInfo> methods ;
 
     private static final Properties debugProps = new Properties() ;
     private static final Properties emptyProps = new Properties() ;
@@ -85,84 +86,19 @@ public class CodegenProxyCreator {
         this.className = className ;
         this.superClass = Type.type( sc ) ;
 
-        this.interfaces = new ArrayList<Type>() ;
+        this.interfaces = new ArrayList<>() ;
         for (Class cls : interfaces) {
             this.interfaces.add( Type.type( cls ) ) ;
         }
 
-        this.methods = new ArrayList<MethodInfo>() ;
+        this.methods = new ArrayList<>() ;
         for (Method method : methods) {
             this.methods.add( Utility.getMethodInfo( method ) ) ;
         }
     }
 
-    /** Construct a generator for a proxy class 
-     * that implements the given interfaces and extends superClass.
-     * superClass must satisfy the following requirements:
-     * <ol>
-     * <li>It must have an accessible no args constructor</li>
-     * <li>It must have a method satisfying the signature
-     * <code>    Object invoke( int methodNumber, Object[] args ) throws Throwable
-     * </code>
-     * </li>
-     * <li>The invoke method described above must be accessible
-     * to the generated class (generally either public or 
-     * protected.</li>
-     * </ol>
-     * <p>
-     * Each method in methods is implemented by a method that:
-     * <ol>
-     * <li>Creates an array sized to hold the args</li>
-     * <li>Wraps args of primitive type in the appropriate wrapper.</li>
-     * <li>Copies each arg or wrapper arg into the array.</li>
-     * <li>Calls invoke with a method number corresponding to the
-     * index of the method in methods.  Note that the invoke implementation
-     * must use the same method array to figure out which method has been
-     * invoked.</li>
-     * <li>Return the result (if any), extracting values from wrappers
-     * as needed to handle a return value of a primitive type.</li>
-     * </ol>
-     * <p>
-     * Note that the generated methods ignore exceptions.
-     * It is assumed that the invoke method may throw any
-     * desired exception.
-     * @param pd the protection domain of the generated class
-     * @param cl the classloader in which to generate the class
-     * @param debug if true, generate debug messages
-     * @param ps a PrintStream to which the debug messages should be written
-     * @return Generator for class
-     * @deprecated use {@link #create(Class, boolean, PrintStream)}
-     */
-    @Deprecated
-    public Class<?> create( ProtectionDomain pd, ClassLoader cl, boolean debug, PrintStream ps ) {
-
-        Pair<String,String> nm = splitClassName( className ) ;
-
-        _clear() ;
-        _setClassLoader( cl ) ;
-        _package( nm.first() ) ;
-        _class( PUBLIC, nm.second(), superClass, interfaces ) ;
-
-        _constructor( PUBLIC ) ;
-        _body() ;
-            _expr(_super());
-        _end() ;
-
-        _method( PRIVATE, _Object(), "writeReplace" ) ;
-        _body() ;
-            _return(_call(_this(), "selfAsBaseClass" )) ;
-        _end() ;
-
-        int ctr=0 ;
-        for (MethodInfo method : methods) 
-            createMethod( ctr++, method ) ;
-    
-        _end() ; // of _class
-
-        return _generate( cl, pd, debug ? debugProps : emptyProps, ps ) ;
-    }
-
-    /** Construct a generator for a proxy class
+    /**
+     * Construct a generator for a proxy class
      * that implements the given interfaces and extends superClass.
      * superClass must satisfy the following requirements:
      * <ol>
@@ -218,8 +154,9 @@ public class CodegenProxyCreator {
         _end() ;
 
         int ctr=0 ;
-        for (MethodInfo method : methods)
+        for (MethodInfo method : methods) {
             createMethod( ctr++, method ) ;
+        }
 
         _end() ; // of _class
 
@@ -231,17 +168,18 @@ public class CodegenProxyCreator {
     private static void createMethod( int mnum, MethodInfo method ) {
         Type rtype = method.returnType() ;
         _method( method.modifiers() & ~ABSTRACT, rtype, method.name()) ;
-        
-        List<Expression> args = new ArrayList<Expression>() ;
-        for (Variable var : method.arguments() ) 
+
+        List<Expression> args = new ArrayList<>() ;
+        for (Variable var : method.arguments() ) {
             args.add( _arg( var.type(), var.ident() ) ) ;
+        }
 
         _body() ;
-            List<Expression> wrappedArgs = new ArrayList<Expression>() ;
+            List<Expression> wrappedArgs = new ArrayList<>() ;
             for (Expression arg : args) {
                 wrappedArgs.add( Primitives.wrap( arg ) ) ;
             }
-            
+
             Expression invokeArgs = _define( objectArrayType, "args",
                 _new_array_init( _Object(), wrappedArgs ) ) ;
 

--- a/orbmain/src/test/java/corba/dynamicrmiiiop/testclasses/IDLLeadingUnderscoresTest.java
+++ b/orbmain/src/test/java/corba/dynamicrmiiiop/testclasses/IDLLeadingUnderscoresTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -23,11 +24,10 @@ public class IDLLeadingUnderscoresTest {
 
     //
     // Set of idl names corresponding to alphabetically sorted set of
-    // interface methods.  See TestIDLNameTranslator for sorting details.    
+    // interface methods.  See TestIDLNameTranslator for sorting details.
     //
-    static final String[] IDL_NAMES = {   
-       
-        "J_",
+    static final String[] IDL_NAMES = {
+
         "J_0",
         "J_J_",
         "J__",
@@ -36,14 +36,12 @@ public class IDLLeadingUnderscoresTest {
         "J_a",
         "J_jj"
     };
-    
+
     public static String[] getIDLNames() {
         return IDL_NAMES;
     }
 
     public interface IDLLeadingUnderscores extends java.rmi.Remote {
-
-        void _() throws java.rmi.RemoteException;
 
         void _0() throws java.rmi.RemoteException;
 
@@ -55,10 +53,10 @@ public class IDLLeadingUnderscoresTest {
 
         void __a() throws java.rmi.RemoteException;
 
-        void _a() throws java.rmi.RemoteException;       
+        void _a() throws java.rmi.RemoteException;
 
-        void _jj() throws java.rmi.RemoteException;       
-        
+        void _jj() throws java.rmi.RemoteException;
+
     }
 
 }

--- a/test/src/share/classes/corba/dynamicrmiiiop/TestCodegenProxyCreator.java
+++ b/test/src/share/classes/corba/dynamicrmiiiop/TestCodegenProxyCreator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -427,7 +428,7 @@ public class TestCodegenProxyCreator extends TestCase {
                         "corba.dynamicrmiiiop.TestInterfaceProxy", 
                         baseClass, interfaces, methods ) ;
 
-                proxyClass = pc.create( pd, loader, DEBUG, System.out ) ;
+                proxyClass = pc.create(this.getClass(), DEBUG, System.out ) ;
             }
 
             try {

--- a/test/src/share/classes/corba/tbbc/Sample.java
+++ b/test/src/share/classes/corba/tbbc/Sample.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -80,7 +81,7 @@ public class Sample {
         }
 
         Class genClass = Sample.class ;
-        Class cls = _generate( genClass.getClassLoader(), genClass.getProtectionDomain(), null ) ;
+        Class cls = _generate( genClass, null ) ;
         
         try {
             Method m = cls.getDeclaredMethod( "main", String[].class ) ;


### PR DESCRIPTION
- Factory renamed to ServantFactory
  - name based on javadoc
  - Factory caused compilation error because it is a keyword
- CodegenProxyCreator.create removed
  - deprecated, because it called deprecated PFL methods which did not work on JDK17+
- IDLLeadingUnderscoresTest - removed test for _() method name
  - Forbidden in JDK21+
  - See JEP 443
- TestCodegenProxyCreator, Sample
  - using different method than the deprecated one

### Merging

- Should be merged after #189 