### PR TITLE
Changing range of supported JDKs from 8-17 to 11-23 + JPMS

### DIFF
--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -64,11 +64,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>com.sun.corba.ee.org.omg.*</Export-Package>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/csiv2-idl/src/main/java/module-info.java
+++ b/csiv2-idl/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.idl {
+
+    requires org.glassfish.corba.omgapi;
+
+    exports com.sun.corba.ee.org.omg.CSI;
+    exports com.sun.corba.ee.org.omg.CSIIOP;
+    exports com.sun.corba.ee.org.omg.GSSUP;
+}

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>org.glassfish.pfl</groupId>
             <artifactId>pfl-basic</artifactId>
-            <version>${pfl-version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/exception-annotation-processor/src/main/java/module-info.java
+++ b/exception-annotation-processor/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.annotation.processing {
+
+    requires java.compiler;
+    requires org.glassfish.pfl.basic;
+}

--- a/exception-annotation-processor/src/main/java/org/glassfish/corba/annotation/processing/ExceptionWrapperProcessor.java
+++ b/exception-annotation-processor/src/main/java/org/glassfish/corba/annotation/processing/ExceptionWrapperProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -19,15 +20,22 @@
 
 package org.glassfish.corba.annotation.processing;
 
-import org.glassfish.pfl.basic.logex.ExceptionWrapper;
-import org.glassfish.pfl.basic.logex.Message;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
-import javax.annotation.processing.*;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
-import java.io.IOException;
-import java.util.*;
+
+import org.glassfish.pfl.basic.logex.ExceptionWrapper;
+import org.glassfish.pfl.basic.logex.Message;
 
 /**
  * This class creates properties files for annotated exception interfaces. Applicable interfaces are annotated with the

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -237,42 +237,6 @@
     </build>
 
     <profiles>
-        <!-- add tools.jar to path when on Linux or Windows -->
-        <profile>
-            <id>tools.jar</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../lib/tools.jar</exists>
-                </file>
-            </activation>
-      	    <dependencies>
-                <dependency>
-                <groupId>com.sun</groupId>
-                <artifactId>tools</artifactId>
-                <version>1.6.0</version>
-                <scope>system</scope>
-                <systemPath>${java.home}/../lib/tools.jar</systemPath>
-            </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <dependencies>
-                            <dependency>
-                                <groupId>com.sun</groupId>
-                                <artifactId>tools</artifactId>
-                                <version>1.6.0</version>
-                                <scope>system</scope>
-                                <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>all-tests</id>
             <build>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -39,8 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
-            <version>${gmbal-version}</version>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -97,7 +96,7 @@
         <dependency>
             <groupId>org.glassfish.external</groupId>
             <artifactId>management-api</artifactId>
-            <version>3.2.3</version>
+            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/idlj/src/main/java/module-info.java
+++ b/idlj/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.idl.compiler {
+
+    // This module does not export any packages
+
+}

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
           <groupId>org.glassfish.pfl</groupId>
           <artifactId>pfl-basic</artifactId>
-          <version>${pfl-version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -35,8 +35,7 @@
     <dependencies>
         <dependency>
           <groupId>org.glassfish.gmbal</groupId>
-          <artifactId>gmbal</artifactId>
-          <version>${gmbal-version}</version>
+          <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
           <groupId>org.glassfish.pfl</groupId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -58,7 +58,9 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package>com.sun.corba.ee.spi.threadpool;version=1, com.sun.corba.ee.impl.threadpool;version=1, com.sun.corba.ee.spi.logex.stdcorba;version=1</Export-Package>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <!-- ThreadPoolImpl is used by glassfish-corba-orb -->
+                        <Export-Package>*</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/internal-api/src/main/java/module-info.java
+++ b/internal-api/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.internal {
+
+    requires org.glassfish.gmbal.api;
+    requires org.glassfish.pfl.basic;
+
+    exports com.sun.corba.ee.impl.threadpool;
+    exports com.sun.corba.ee.spi.logex.stdcorba;
+    exports com.sun.corba.ee.spi.threadpool;
+}

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -64,13 +64,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.omg.*; version=1, com.sun.*;version=1, javax.rmi;version=1, javax.rmi.CORBA;version=1</Export-Package>
-                        <Import-Package>!org.omg.PortableServer.ServantLocatorPackage</Import-Package>
-                        <Fragment-Host>system.bundle; extension:=framework</Fragment-Host>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/omgapi/src/main/java/module-info.java
+++ b/omgapi/src/main/java/module-info.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.omgapi {
+
+    requires java.desktop;
+    requires java.logging;
+    requires java.rmi;
+
+    exports com.sun.corba.ee.org.omg.CORBA;
+    exports javax.rmi;
+    exports javax.rmi.CORBA;
+    exports org.omg.CORBA;
+    exports org.omg.CORBA.ContainedPackage;
+    exports org.omg.CORBA.ContainerPackage;
+    exports org.omg.CORBA.InterfaceDefPackage;
+    exports org.omg.CORBA.ValueDefPackage;
+    exports org.omg.CORBA_2_3;
+    exports org.omg.CORBA_2_3.portable;
+    exports org.omg.CORBA.DynAnyPackage;
+    exports org.omg.CORBA.ORBPackage;
+    exports org.omg.CORBA.portable;
+    exports org.omg.CORBA.TSIdentificationPackage;
+    exports org.omg.CORBA.TypeCodePackage;
+    exports org.omg.CosNaming;
+    exports org.omg.CosNaming.NamingContextExtPackage;
+    exports org.omg.CosNaming.NamingContextPackage;
+    exports org.omg.CosTransactions;
+    exports org.omg.CosTSPortability;
+    exports org.omg.CosTSInteroperation;
+    exports org.omg.Dynamic;
+    exports org.omg.DynamicAny;
+    exports org.omg.DynamicAny.DynAnyFactoryPackage;
+    exports org.omg.DynamicAny.DynAnyPackage;
+    exports org.omg.IOP;
+    exports org.omg.IOP.CodecFactoryPackage;
+    exports org.omg.IOP.CodecPackage;
+    exports org.omg.Messaging;
+    exports org.omg.PortableInterceptor;
+    exports org.omg.PortableInterceptor.ORBInitInfoPackage;
+    exports org.omg.PortableServer;
+    exports org.omg.PortableServer.CurrentPackage;
+    exports org.omg.PortableServer.POAManagerPackage;
+    exports org.omg.PortableServer.POAPackage;
+    exports org.omg.PortableServer.portable;
+    exports org.omg.PortableServer.ServantLocatorPackage;
+    exports org.omg.SendingContext;
+    exports org.omg.SendingContext.CodeBasePackage;
+    exports org.omg.TimeBase;
+    exports org.omg.stub.java.rmi;
+
+    opens org.omg.CORBA;
+}

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -105,27 +105,25 @@
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            !com.sun.corba.ee.spi.threadpool, !com.sun.corba.ee.spi.logex.stdcorba,
-                            com.sun.corba.ee.spi.*; version=1,
-                            com.sun.corba.ee.impl.corba; version=1,
-                            com.sun.corba.ee.impl.encoding.*; version=1,
-                            com.sun.corba.ee.impl.folb; version=1,
-                            com.sun.corba.ee.impl.javax.*; version=1,
-                            com.sun.corba.ee.impl.misc; version=1,
-                            com.sun.corba.ee.impl.naming.*; version=1,
-                            com.sun.corba.ee.impl.oa.*; version=1,
-                            com.sun.corba.ee.impl.orb; version=1,
-                            com.sun.corba.ee.impl.presentation.*; version=1,
-                            com.sun.corba.ee.impl.txpoa; version=1,
-                            com.sun.corba.ee.impl.util; version=1,
-                            org.glassfish.jndi.*; version=1
+                            com.sun.corba.ee.spi.*,
+                            com.sun.corba.ee.impl.corba,
+                            com.sun.corba.ee.impl.encoding.*,
+                            com.sun.corba.ee.impl.folb,
+                            com.sun.corba.ee.impl.javax.*,
+                            com.sun.corba.ee.impl.misc,
+                            com.sun.corba.ee.impl.naming.*,
+                            com.sun.corba.ee.impl.oa.*,
+                            com.sun.corba.ee.impl.orb,
+                            com.sun.corba.ee.impl.presentation.*,
+                            com.sun.corba.ee.impl.txpoa,
+                            com.sun.corba.ee.impl.util,
+                            org.glassfish.jndi.*
                         </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>
-            
+
             <!-- generate test idl -->
-            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>idlj-maven-plugin</artifactId>
@@ -140,7 +138,10 @@
                     <sources>
                         <source>
                             <packagePrefixes>
-                                <packagePrefix><type>interceptors</type><prefix>com.sun.corba.ee.impl</prefix></packagePrefix>
+                                <packagePrefix>
+                                    <type>interceptors</type>
+                                    <prefix>com.sun.corba.ee.impl</prefix>
+                                </packagePrefix>
                             </packagePrefixes>
                         </source>
                     </sources>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -48,20 +48,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>exception-annotation-processor</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>6.0.0</version>
+            <artifactId>osgi.core</artifactId>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
           <groupId>org.glassfish.gmbal</groupId>
-          <artifactId>gmbal</artifactId>
-          <version>${gmbal-version}</version>
+          <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
           <groupId>org.glassfish.pfl</groupId>
@@ -95,10 +88,30 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <!-- It is used just by compiler, so we need to ensure order of build of modules. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>exception-annotation-processor</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>exception-annotation-processor</artifactId>
+                            <version>${project.version}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/orbmain/src/main/java/module-info.java
+++ b/orbmain/src/main/java/module-info.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.orb {
+
+    requires java.desktop;
+    requires java.logging;
+    requires java.naming;
+    requires java.rmi;
+    requires java.sql;
+
+    requires org.glassfish.corba.internal;
+    requires org.glassfish.corba.omgapi;
+
+    requires org.glassfish.gmbal.api;
+
+    requires org.glassfish.pfl.basic;
+    requires org.glassfish.pfl.dynamic;
+    requires org.glassfish.pfl.tf;
+
+    requires osgi.core;
+
+    exports com.sun.corba.ee.impl.javax.rmi;
+    exports com.sun.corba.ee.impl.javax.rmi.CORBA;
+    exports com.sun.corba.ee.impl.legacy.connection;
+    exports com.sun.corba.ee.impl.orb;
+    exports com.sun.corba.ee.impl.util;
+    exports com.sun.corba.ee.spi.transport;
+
+    opens com.sun.corba.ee.impl.oa.poa;
+    opens com.sun.corba.ee.impl.oa.toa;
+    opens com.sun.corba.ee.spi.ior;
+    opens com.sun.corba.ee.spi.orb;
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -250,8 +250,6 @@
                         <execution>
                             <goals>
                                 <goal>manifest</goal>
-                                <goal>install</goal>
-                                <goal>deploy</goal>
                             </goals>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.9</version>
-        <relativePath/>  
+        <relativePath/>
     </parent>
 
     <groupId>org.glassfish.corba</groupId>
@@ -104,9 +104,7 @@
         <copyright.template>make/copyright-information/copyright.txt</copyright.template>
         <copyright.update>false</copyright.update>
 
-        <jdkVersion>8</jdkVersion>
-        <maven.compiler.source>${jdkVersion}</maven.compiler.source>
-        <maven.compiler.target>${jdkVersion}</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.dynamicAnalysis>false</sonar.dynamicAnalysis>
         <pfl-version>5.0.0</pfl-version>
@@ -176,7 +174,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -334,7 +331,7 @@
                     <version>3.8.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId> 
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.5.0</version>
                 </plugin>
@@ -343,7 +340,7 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>3.2.7</version>
                 </plugin>
-                <plugin> 
+                <plugin>
                      <groupId>org.apache.maven.plugins</groupId>
                      <artifactId>maven-source-plugin</artifactId>
                      <version>3.3.1</version>
@@ -352,7 +349,7 @@
                      <groupId>org.apache.maven.plugins</groupId>
                      <artifactId>maven-javadoc-plugin</artifactId>
                      <version>3.11.2</version>
-                </plugin>  
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -412,18 +409,6 @@
     </reporting>
 
     <profiles>
-
-        <!-- ignore javadoc lint checks, enabled by default in JDK 1.8 (really want to run based on toolchain selection) -->
-        <profile>
-            <id>disable-java8-doclint</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <additionalparam>-Xdoclint:none</additionalparam>
-            </properties>
-        </profile>
-        
         <profile>
             <!-- include required legal artifacts in module jars -->
             <id>install-legal-files</id>
@@ -463,13 +448,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-          <id>compiler-release-with-jdk9plus</id>
-            <activation>
-              <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-              <maven.compiler.release>${jdkVersion}</maven.compiler.release>
-            </properties>
-        </profile>    </profiles>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.dynamicAnalysis>false</sonar.dynamicAnalysis>
-        <pfl-version>5.0.0</pfl-version>
-        <gmbal-version>4.0.3</gmbal-version>
+        <pfl-version>5.1.0</pfl-version>
+        <gmbal-version>4.1.0</gmbal-version>
     </properties>
 
     <dependencyManagement>
@@ -165,6 +165,17 @@
                 <groupId>org.glassfish.pfl</groupId>
                 <artifactId>pfl-test</artifactId>
                 <version>${pfl-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.gmbal</groupId>
+                <artifactId>gmbal</artifactId>
+                <version>${gmbal-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.gmbal</groupId>
+                <artifactId>gmbal-api-only</artifactId>
+                <version>${gmbal-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -67,19 +67,12 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration combine.self="override">
+                <configuration>
                     <archive>
                         <manifest>
                             <mainClass>org.glassfish.rmic.Main</mainClass>
                         </manifest>
-                        <manifestEntries>
-                            <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-Vendor>Eclipse Foundation</Implementation-Vendor>
-                        </manifestEntries>
                     </archive>
-                    <instructions>
-                        <Export-Package>org.glassfish.rmic.*</Export-Package>
-                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/rmic/src/main/java/module-info.java
+++ b/rmic/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+module org.glassfish.corba.rmic {
+
+    requires java.rmi;
+
+    requires org.objectweb.asm;
+    requires org.glassfish.corba.omgapi;
+    requires org.glassfish.corba.orb;
+
+}

--- a/rmic/src/test/java/org/glassfish/rmic/tools/javac/BatchEnvironmentTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/tools/javac/BatchEnvironmentTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,17 +17,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause OR GPL-2.0 WITH
  * Classpath-exception-2.0
  */
-
 package org.glassfish.rmic.tools.javac;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import com.meterware.simplestub.SystemPropertySupport;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.glassfish.rmic.BatchEnvironmentError;
 import org.glassfish.rmic.asm.AsmClassFactory;
 import org.glassfish.rmic.tools.binaryclass.BinaryClassFactory;
@@ -35,6 +34,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 
 @SuppressWarnings("deprecation")
 public class BatchEnvironmentTest {
@@ -57,7 +59,9 @@ public class BatchEnvironmentTest {
 
     @After
     public void tearDown() throws Exception {
-        for (Memento memento : mementos) memento.revert();
+        for (Memento memento : mementos) {
+            memento.revert();
+        }
     }
 
     @Test
@@ -141,6 +145,27 @@ public class BatchEnvironmentTest {
     public void whenLegacyParserRequestedOnJdk11_chooseAsmParser() throws Exception {
         preferLegacyParser();
         simulateJdkVersion("11");
+
+        ClassDefinitionFactory factory = BatchEnvironment.createClassDefinitionFactory();
+
+        assertThat(factory, instanceOf(AsmClassFactory.class));
+    }
+
+    @Test
+    public void whenLegacyParserRequestedOnJdk17_chooseAsmParser() throws Exception {
+        preferLegacyParser();
+        simulateJdkVersion("17");
+
+        ClassDefinitionFactory factory = BatchEnvironment.createClassDefinitionFactory();
+
+        assertThat(factory, instanceOf(AsmClassFactory.class));
+    }
+
+
+    @Test
+    public void whenLegacyParserRequestedOnJdk21_chooseAsmParser() throws Exception {
+        preferLegacyParser();
+        simulateJdkVersion("21");
 
         ClassDefinitionFactory factory = BatchEnvironment.createClassDefinitionFactory();
 


### PR DESCRIPTION
* Uses latest ORB libs (currently snapshots)
* Rebase and merge after 
  * merge of #194 
  * release of [PFL](https://github.com/eclipse-ee4j/orb-gmbal-pfl/milestone/2) and [GMBAL](https://github.com/eclipse-ee4j/orb-gmbal/milestone/3)
  * Complete testing with GlassFish
