### PR TITLE
Add option to skip gmbal init

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAFactory.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAFactory.java
@@ -180,7 +180,9 @@ public class POAFactory implements ObjectAdapterFactory
             NullaryFunction.Factory.makeConstant( 
                 (org.omg.CORBA.Object)poaCurrent ) ) ;
         this.mom = orb.mom() ;
-        mom.registerAtRoot( this ) ;
+        if (mom != null) {
+            mom.registerAtRoot( this ) ;
+        }
     }
 
     public ObjectAdapter find( ObjectAdapterId oaid )

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAImpl.java
@@ -316,7 +316,9 @@ public class POAImpl extends ObjectAdapterBase implements POA
 
     @Poa
     private static void registerMBean( ORB orb, Object obj ) {
-        orb.mom().register( getPOAFactory( orb ), obj ) ;
+        if (orb.mom() != null) {
+            orb.mom().register( getPOAFactory( orb ), obj ) ;
+        }
     }
 
     // package private so that POAFactory can access it.

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/oa/toa/TOAFactory.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/oa/toa/TOAFactory.java
@@ -81,7 +81,9 @@ public class TOAFactory implements ObjectAdapterFactory
         this.orb = orb ;
         tom = new TransientObjectManager( orb ) ;
         codebaseToTOA = new HashMap<String,TOAImpl>() ;
-        orb.mom().registerAtRoot( this ) ;
+        if (orb.mom() != null) {
+            orb.mom().registerAtRoot( this ) ;
+        }
     }
 
     public void shutdown( boolean waitForCompletion )

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
@@ -141,7 +141,9 @@ import org.glassfish.pfl.basic.contain.StackImpl;
 import org.glassfish.pfl.basic.contain.ResourceFactory;
 import org.glassfish.pfl.basic.func.NullaryFunction;
 import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
-         
+
+import static com.sun.corba.ee.spi.misc.ORBConstants.SKIP_GMBAL_INIT;
+
 /**
  * The JavaIDL ORB implementation.
  */
@@ -550,7 +552,9 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB
         setDebugFlags( configData.getORBDebugFlags() ) ;
         configDataParsingComplete( getORBData().getORBId() ) ;
 
-        initManagedObjectManager() ;
+        if (!Boolean.parseBoolean(System.getProperty(SKIP_GMBAL_INIT, "false"))) {
+            initManagedObjectManager() ;
+        }
 
         // The TimerManager must be
         // initialized BEFORE the pihandler.initialize() call, in
@@ -618,8 +622,10 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB
 
         // Now the ORB is ready, so finish all of the MBean registration
         if (configData.registerMBeans()) {
-            mom.resumeJMXRegistration() ;
-            mbeansRegistereed( getORBData().getORBId() ) ;
+            if (mom != null) {
+                mom.resumeJMXRegistration() ;
+                mbeansRegistereed( getORBData().getORBId() ) ;
+            }
         }
     }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/TransportManagerImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/TransportManagerImpl.java
@@ -73,7 +73,9 @@ public class TransportManagerImpl
         outboundConnectionCaches = new HashMap<String,OutboundConnectionCache>();
         inboundConnectionCaches = new HashMap<String,InboundConnectionCache>();
         selector = new SelectorImpl(orb);
-        orb.mom().register( orb, this ) ;
+        if (orb.mom() != null) {
+            orb.mom().register( orb, this ) ;
+        }
     }
 
     public ByteBufferPool getByteBufferPool(int id)
@@ -99,7 +101,9 @@ public class TransportManagerImpl
 
                         // We need to clean up the multi-cache support:
                         // this really only works with a single cache.
-                        orb.mom().register( this, connectionCache ) ;
+                        if (orb.mom() != null) {
+                            orb.mom().register( this, connectionCache ) ;
+                        }
                         StatsProviderManager.register( "orb", PluginPoint.SERVER,
                             "orb/transport/connectioncache/outbound", connectionCache ) ;
 
@@ -139,7 +143,9 @@ public class TransportManagerImpl
                         connectionCache = 
                             new InboundConnectionCacheImpl(orb,
                                                                 acceptor);
-                        orb.mom().register( this, connectionCache ) ;
+                        if (orb.mom() != null) {
+                            orb.mom().register( this, connectionCache ) ;
+                        }
                         StatsProviderManager.register( "orb", PluginPoint.SERVER,
                             "orb/transport/connectioncache/inbound", connectionCache ) ;
 

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -181,6 +181,7 @@ public class ORBConstants {
     public static final String SERVER_PORT_PROPERTY             = SUN_PREFIX + "ORBServerPort" ;
     public static final String SERVER_HOST_PROPERTY             = SUN_PREFIX + "ORBServerHost" ;
     public static final String ORB_ID_PROPERTY                  = CORBA_PREFIX + "ORBId" ;
+    public static final String SKIP_GMBAL_INIT                  = CORBA_PREFIX + "SkipGmbalInit" ;
     // This property is provided for backward compatibility reasons
     public static final String OLD_ORB_ID_PROPERTY              = SUN_PREFIX + "ORBid" ;
     public static final String ORB_SERVER_ID_PROPERTY           = CORBA_PREFIX + "ORBServerId" ;


### PR DESCRIPTION
Credit to David Weaver

Add option to include -Dorg.omg.CORBA.SkipGmbalInit=true to java runtime environment to bypass gmbal mbean initialisation for performance increase
