### PR TITLE
Fixed dependencies - caused failures in tests

### DIFF
--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -88,6 +88,11 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- It is used just by compiler, so we need to ensure order of build of modules. -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/orbmain/src/main/java/module-info.java
+++ b/orbmain/src/main/java/module-info.java
@@ -25,6 +25,8 @@ module org.glassfish.corba.orb {
     requires org.glassfish.corba.internal;
     requires org.glassfish.corba.omgapi;
 
+    requires org.glassfish.external.management.api;
+
     requires org.glassfish.gmbal.api;
 
     requires org.glassfish.pfl.basic;
@@ -33,11 +35,13 @@ module org.glassfish.corba.orb {
 
     requires osgi.core;
 
+    exports com.sun.corba.ee.impl.ior;
     exports com.sun.corba.ee.impl.javax.rmi;
     exports com.sun.corba.ee.impl.javax.rmi.CORBA;
     exports com.sun.corba.ee.impl.legacy.connection;
     exports com.sun.corba.ee.impl.orb;
     exports com.sun.corba.ee.impl.util;
+    exports com.sun.corba.ee.spi.ior.iiop;
     exports com.sun.corba.ee.spi.transport;
 
     opens com.sun.corba.ee.impl.oa.poa;


### PR DESCRIPTION
This combined with https://github.com/eclipse-ee4j/orb-gmbal/pull/56 and https://github.com/eclipse-ee4j/orb-gmbal-pfl/pull/94 and https://github.com/eclipse-ee4j/glassfish/pull/25364 + locally changed versions to combine snapshots passed GlassFish's jdbc_group3 tests.

Note: I will restage 5.0.0 after merging this.