### PR TITLE
Added osgi.loader to exports

### DIFF
--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -132,6 +132,7 @@
                             com.sun.corba.ee.impl.naming.*,
                             com.sun.corba.ee.impl.oa.*,
                             com.sun.corba.ee.impl.orb,
+                            com.sun.corba.ee.impl.osgi.loader.*,
                             com.sun.corba.ee.impl.presentation.*,
                             com.sun.corba.ee.impl.txpoa,
                             com.sun.corba.ee.impl.util,


### PR DESCRIPTION
- GlassFish started requiring that after refactoring

```
MultiException stack 3 of 9
java.lang.IllegalStateException: Unable to resolve
    org.glassfish.main.orb.iiop [141]
    missing requirement
        package = com.sun.corba.ee.impl.osgi.loader

        at org.glassfish.common.util.admin.GlassFishErrorServiceImpl.onFailure(GlassFishErrorServiceImpl.java:69)
        at org.jvnet.hk2.internal.Utilities.handleErrors(Utilities.java:350)
        at org.jvnet.hk2.internal.ServiceLocatorImpl.igdCacheCompute(ServiceLocatorImpl.java:1217)
        at org.jvnet.hk2.internal.ServiceLocatorImpl$8.compute(ServiceLocatorImpl.java:1198)
        at org.jvnet.hk2.internal.ServiceLocatorImpl$8.compute(ServiceLocatorImpl.java:1195)
        at org.glassfish.hk2.utilities.cache.internal.WeakCARCacheImpl.compute(WeakCARCacheImpl.java:108)
        at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetDescriptor(ServiceLocatorImpl.java:1278)
        at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetInjecteeDescriptor(ServiceLocatorImpl.java:579)
        at org.jvnet.hk2.internal.ServiceLocatorImpl.getInjecteeDescriptor(ServiceLocatorImpl.java:588)
        at org.jvnet.hk2.internal.ThreeThirtyResolver.resolve(ThreeThirtyResolver.java:47)
        at org.jvnet.hk2.internal.ClazzCreator.resolve(ClazzCreator.java:197)
        at org.jvnet.hk2.internal.ClazzCreator.resolveAllDependencies(ClazzCreator.java:234)
        at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:387)
        at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:479)
        at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:61)
        at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:49)

```