### PR TITLE
Deploy to Maven Central, including snapshot support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <name>ORB Implementation</name>
+    <name>GlassFish ORB</name>
     <packaging>pom</packaging>
-    <description>A CORBA ORB for Glassfish</description>
+    <description>A CORBA ORB Implementation for Glassfish</description>
 
     <url>https://projects.eclipse.org/proposals/eclipse-orb</url>
 
@@ -69,6 +69,28 @@
     </scm>
 
     <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>Disabled Sonatype Nexus</name>
+            <url>http://localhost</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <name>Disabled Sonatype Nexus</name>
+            <url>http://localhost</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
         <site>
             <id>github</id>
             <url>scm:git:https://github.com/eclipse-ee4j/orb.git</url>
@@ -103,6 +125,7 @@
         <copyright.scmonly>true</copyright.scmonly>
         <copyright.template>make/copyright-information/copyright.txt</copyright.template>
         <copyright.update>false</copyright.update>
+        <deploy.skip>false</deploy.skip>
 
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -391,33 +414,45 @@
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.4</version>
+                    <configuration>
+                        <deployAtEnd>true</deployAtEnd>
+                        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+                        <skip>${deploy.skip}</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                    <configuration>
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>injected-nexus-deploy</id>
+                            <phase>none</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.9.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <autoPublish>true</autoPublish>
+                        <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
+                        <deploymentName>GlassFish ORB ${project.version}</deploymentName>
+                        <publishingServerId>central</publishingServerId>
+                        <waitUntil>published</waitUntil>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
-
-    <reporting>
-      <plugins>
-<!--
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.1</version>
-          <configuration>
-               <findbugsXmlOutput>true</findbugsXmlOutput>
-               <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-               <xmlOutput>true</xmlOutput>
-          </configuration>
-        </plugin>
--->
-<!--
-        <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>cobertura-maven-plugin</artifactId>
-            <version>2.5.1</version>
-        </plugin>
--->
-      </plugins>
-    </reporting>
 
     <profiles>
         <profile>
@@ -488,6 +523,67 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>oss-release</id>
+            <properties>
+                <!-- Until we fix everything -->
+                <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.cyclonedx</groupId>
+                        <artifactId>cyclonedx-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>makeAggregateBom</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Note: Releases should not depend on milestones. Until parent releases final 2.0, we should keep on with 1.0.9.

The new job using this: https://ci.eclipse.org/orb/job/deploy-to-central/
It can be used to deploy the release too.
