### PR TITLE
Make imported applet packages optional

### DIFF
--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -64,6 +64,13 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <!-- Explicitly mark java.applet as optional because it's not supported on Java 26, 
+                        then append everything else (*) Bnd finds -->
+                        <Import-Package>java.applet;resolution:=optional,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -122,6 +122,9 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <!-- Explicitly mark java.applet as optional because it's not supported on Java 26, 
+                        then append everything else (*) Bnd finds -->
+                        <Import-Package>java.applet;resolution:=optional,*</Import-Package>
                         <Export-Package>
                             com.sun.corba.ee.spi.*,
                             com.sun.corba.ee.impl.corba,


### PR DESCRIPTION
Applets were removed from Java 26, they cannot be imported if running on Java 26 or newer. Making them optional will allow using the functionality on Java 26 that doesn't depend on applets.