### PR TITLE
Improvements in logging

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/ior/ObjectKeyImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/ior/ObjectKeyImpl.java
@@ -104,8 +104,13 @@ public class ObjectKeyImpl implements ObjectKey
         return array.clone() ;
     }
 
-    public ServerRequestDispatcher getServerRequestDispatcher()
-    {
-        return oktemp.getServerRequestDispatcher( id ) ;
+    @Override
+    public ServerRequestDispatcher getServerRequestDispatcher() {
+        return oktemp.getServerRequestDispatcher(id);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[id=" + id + "]";
     }
 }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/ior/WireObjectKeyTemplate.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/ior/WireObjectKeyTemplate.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -35,95 +36,94 @@ import org.omg.CORBA_2_3.portable.OutputStream ;
 /**
  * @author Ken Cavanaugh
  */
-public class WireObjectKeyTemplate implements ObjectKeyTemplate 
-{
-    private ORB orb ;
-    private static final IORSystemException wrapper =
-        IORSystemException.self ;
-    private static ObjectAdapterId NULL_OBJECT_ADAPTER_ID = 
-        new ObjectAdapterIdArray( new String[0] ) ;
+public class WireObjectKeyTemplate implements ObjectKeyTemplate {
+
+    private static final IORSystemException WRAPPER = IORSystemException.self;
+    private static final ObjectAdapterId NULL_OBJECT_ADAPTER_ID = new ObjectAdapterIdArray(new String[0]);
+
+    private ORB orb;
+
+    public WireObjectKeyTemplate(ORB orb) {
+        this.orb = orb;
+    }
 
     @Override
-    public boolean equals( Object obj )
-    {
+    public boolean equals(Object obj) {
         if (obj == null) {
-            return false ;
+            return false;
         }
-
-        return obj instanceof WireObjectKeyTemplate ;
+        return obj instanceof WireObjectKeyTemplate;
     }
 
     @Override
-    public int hashCode()
-    {
-        return 53 ; // All WireObjectKeyTemplates are the same, so they should 
-                    // have the same hashCode.
+    public int hashCode() {
+        return 53; // All WireObjectKeyTemplates are the same, so they should
+                   // have the same hashCode.
     }
 
-    public WireObjectKeyTemplate( ORB orb )
-    {
-        initORB( orb ) ;
+    @Override
+    public void write(ObjectId id, OutputStream os) {
+        byte[] key = id.getId();
+        os.write_octet_array(key, 0, key.length);
     }
 
-    private void initORB( ORB orb ) 
-    {
-        this.orb = orb ;
-    }
-
-    public void write( ObjectId id, OutputStream os ) 
-    {
-        byte[] key = id.getId() ;
-        os.write_octet_array( key, 0, key.length ) ;
-    }
-
-    public void write( OutputStream os ) 
-    {
+    @Override
+    public void write(OutputStream os) {
         // Does nothing
     }
 
-    public int getSubcontractId()
-    {
-        return ORBConstants.DEFAULT_SCID ;
+    @Override
+    public int getSubcontractId() {
+        return ORBConstants.DEFAULT_SCID;
     }
 
     // While it might make sense to throw an exception here, this causes
     // problems since we need to check whether unusual object references
-    // are local or not.  It seems that the easiest way to handle this is
+    // are local or not. It seems that the easiest way to handle this is
     // to return an invalid server id.
-    public int getServerId() 
-    {
-        return -1 ;
+    @Override
+    public int getServerId() {
+        return -1;
     }
 
-    public String getORBId()
-    {
-        throw wrapper.orbIdNotAvailable() ;
+    @Override
+    public String getORBId() {
+        throw WRAPPER.orbIdNotAvailable();
     }
 
-    public ObjectAdapterId getObjectAdapterId() 
-    {
-        return NULL_OBJECT_ADAPTER_ID ;
-
-        // throw wrapper.objectAdapterIdNotAvailable() ;
+    @Override
+    public ObjectAdapterId getObjectAdapterId() {
+        return NULL_OBJECT_ADAPTER_ID;
     }
+
 
     // Adapter ID is not available, since our
     // ORB did not implement the object carrying this key.
-    public byte[] getAdapterId()
-    {
-        throw wrapper.adapterIdNotAvailable() ;
+    @Override
+    public byte[] getAdapterId() {
+        throw WRAPPER.adapterIdNotAvailable();
     }
 
-    public ORBVersion getORBVersion() 
-    {
-        return ORBVersionFactory.getFOREIGN() ;
+
+    @Override
+    public ORBVersion getORBVersion() {
+        return ORBVersionFactory.getFOREIGN();
     }
 
-    public ServerRequestDispatcher getServerRequestDispatcher( ObjectId id )
-    {
-        byte[] bid = id.getId() ;
-        String str = new String( bid ) ;
-        return orb.getRequestDispatcherRegistry().getServerRequestDispatcher(
-            str ) ;
+
+    @Override
+    public ServerRequestDispatcher getServerRequestDispatcher(ObjectId id) {
+        byte[] bid = id.getId();
+        String str = new String(bid);
+        return orb.getRequestDispatcherRegistry().getServerRequestDispatcher(str);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName()
+            + "[subcontractId=" + getSubcontractId()
+            + " serverId=" + getServerId()
+            + " objectadapterId=" + getObjectAdapterId()
+            + "]";
     }
 }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/legacy/connection/SocketFactoryAcceptorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/legacy/connection/SocketFactoryAcceptorImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -58,17 +59,6 @@ public class SocketFactoryAcceptorImpl
         }
         initialized = true;
         return true;
-    }
-
-    ////////////////////////////////////////////////////
-    //
-    // Implementation.
-    //
-
-    @Override
-    protected String toStringName()
-    {
-        return "SocketFactoryAcceptorImpl";
     }
 
     // Fix for 6331566.

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/misc/ORBUtility.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/misc/ORBUtility.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2019 Payara Services Ltd.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,6 +42,7 @@ import com.sun.corba.ee.spi.transport.ContactInfoList ;
 import java.io.IOException ;
 import java.io.PrintStream ;
 import java.io.Serializable;
+import java.lang.System.Logger;
 import java.net.SocketAddress ;
 import java.nio.ByteBuffer ;
 import java.nio.channels.SocketChannel ;
@@ -68,10 +70,14 @@ import org.omg.CORBA.TypeCodePackage.BadKind ;
 import org.omg.CORBA.portable.InputStream ;
 import org.omg.CORBA.portable.OutputStream ;
 
+import static java.lang.System.Logger.Level.DEBUG;
+
 /**
  *  Handy class full of static functions that don't belong in util.Utility for pure ORB reasons.
  */
 public final class ORBUtility {
+    private static final Logger LOG = System.getLogger(ORBUtility.class.getName());
+
     /** Utility method for working around leak in SocketChannel.open( SocketAddress )
      * method.
      * @param sa address to connect to
@@ -79,24 +85,20 @@ public final class ORBUtility {
      * @throws java.io.IOException If an I/O error occurs
      * @see SocketChannel#connect(java.net.SocketAddress)
      */
-    public static SocketChannel openSocketChannel( SocketAddress sa ) 
-        throws IOException {
-
-        SocketChannel sc = SocketChannel.open() ;
-
+    public static SocketChannel openSocketChannel(SocketAddress sa) throws IOException {
+        LOG.log(DEBUG, "openSocketChannel({0})", sa);
+        SocketChannel sc = SocketChannel.open();
         try {
-            sc.connect( sa ) ;
-            return sc ;
-        } catch (RuntimeException | IOException exc ) {
+            sc.connect(sa);
+            return sc;
+        } catch (RuntimeException | IOException exc) {
             try {
-                sc.close() ;
+                sc.close();
             } catch (IOException ioe) {
-                // Ignore this: close exceptions are useless.
+                exc.addSuppressed(ioe);
             }
-
-            throw exc ;
+            throw exc;
         }
-        
     }
 
     private static final ThreadLocal<LinkedList<Byte>> encVersionThreadLocal =

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBConfiguratorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBConfiguratorImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -61,6 +62,7 @@ import com.sun.corba.ee.spi.transport.ContactInfoListFactory;
 import com.sun.corba.ee.spi.transport.SocketInfo;
 import com.sun.corba.ee.spi.transport.TransportDefault ;
 
+import java.lang.System.Logger;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController ;
@@ -69,7 +71,10 @@ import java.security.PrivilegedExceptionAction ;
 import org.glassfish.pfl.basic.func.NullaryFunction;
 import org.glassfish.pfl.dynamic.copyobject.spi.ObjectCopierFactory;
 
+import static java.lang.System.Logger.Level.TRACE;
+
 public class ORBConfiguratorImpl implements ORBConfigurator {
+    private static final Logger LOG = System.getLogger(ORBConfiguratorImpl.class.getName());
     private static final ORBUtilSystemException wrapper =
         ORBUtilSystemException.self ;
 
@@ -99,8 +104,10 @@ public class ORBConfiguratorImpl implements ORBConfigurator {
         }
     }
 
-    public void configure( DataCollector collector, ORB orb ) 
+    @Override
+    public void configure( DataCollector collector, ORB orb )
     {
+        LOG.log(TRACE, "configure(collector, orb)");
         ORB theOrb = orb ;
 
         initObjectCopiers( theOrb ) ;

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -91,9 +92,11 @@ import com.sun.org.omg.SendingContext.CodeBase;
 
 import java.applet.Applet;
 import java.io.IOException ;
+import java.lang.System.Logger;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress ;
 import java.util.ArrayList ;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.HashMap ;
 import java.util.HashSet ;
@@ -107,8 +110,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock ;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.rmi.CORBA.ValueHandler;
 
@@ -133,14 +134,16 @@ import org.omg.CORBA.ORBPackage.InvalidName;
 import org.omg.CORBA.portable.ValueFactory;
 
 import static com.sun.corba.ee.spi.misc.ORBConstants.SKIP_GMBAL_INIT;
+import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 
 /**
  * The JavaIDL ORB implementation.
  */
 @OrbLifeCycle
 @Subcontract
-public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB
-{
+public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
+    private static final Logger LOG = System.getLogger(ORBImpl.class.getName());
     private boolean set_parameters_called = false ;
 
     protected TransportManager transportManager;
@@ -468,13 +471,12 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB
             if (!disableORBD) {
                 // Note: this class is NOT included in the GF bundles!
                 // Try to load it if present.
-                String cname = 
-                    "com.sun.corba.ee.impl.activation.ORBConfiguratorPersistentImpl" ;
+                String cname = "com.sun.corba.ee.impl.activation.ORBConfiguratorPersistentImpl";
 
                 try {
                     configurator = Class.forName(cname);
-                } catch (ClassNotFoundException ex) {
-                    Logger.getLogger(ORBImpl.class.getName()).log(Level.FINE, null, ex);
+                } catch (ClassNotFoundException e) {
+                    LOG.log(TRACE, "Failed to load alternative configurator class " + cname, e);
                 }
             }
         }
@@ -1707,20 +1709,26 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB
         return serviceContextsCache;
     }
 
-    // XXX All of the isLocalYYY checking needs to be revisited.
-    // First of all, all three of these methods are called from
-    // only one place in impl.ior.IORImpl.  Second, we have problems
-    // both with multi-homed hosts and with multi-profile IORs.
-    // A possible strategy: like the LocalClientRequestDispatcher, we need
-    // to determine this more abstractly at the ContactInfo level.
-    // This level should probably just get the CorbaContactInfoList from
-    // the IOR, then iterator over ContactInfo.  If any ContactInfo is
-    // local, the IOR is local, and we can pick one to create the 
-    // LocalClientRequestDispatcher as well.  Bottom line: this code needs to move.
-    public boolean isLocalHost( String hostName ) 
-    {
-        return hostName.equals( configData.getORBServerHost() ) ||
-            hostName.equals( getLocalHostName() ) ;
+    @Override
+    public boolean isLocalHost(String hostName) {
+        try {
+            return hostName.equals(configData.getORBServerHost())
+                || hostName.equals(getLocalHostName())
+                || isLocalHost(InetAddress.getByName(hostName));
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    private boolean isLocalHost(InetAddress address) {
+        if (address.isLoopbackAddress()) {
+            return true;
+        }
+        String ip = address.getHostAddress();
+        if (ip == null) {
+            return false;
+        }
+        return ip.equals(configData.getORBServerHost()) || ip.equals(getLocalHostName());
     }
 
     @Subcontract
@@ -1753,41 +1761,32 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB
         }
     }
 
-    /*************************************************************************
-     *  The following public methods are for ORB shutdown.
-     *************************************************************************/
-
-    private String getHostName(String host) 
-        throws java.net.UnknownHostException 
-    {
-        return InetAddress.getByName( host ).getHostAddress();
-    }
-
-    /* keeping a copy of the getLocalHostName so that it can only be called 
+    /* keeping a copy of the getLocalHostName so that it can only be called
      * internally and the unauthorized clients cannot have access to the
-     * localHost information, originally, the above code was calling 
-     * getLocalHostName from Connection.java.  If the hostname is cached in 
+     * localHost information, originally, the above code was calling
+     * getLocalHostName from Connection.java.  If the hostname is cached in
      * Connection.java, then
      * it is a security hole, since any unauthorized client has access to
      * the host information.  With this change it is used internally so the
-     * security problem is resolved.  Also in Connection.java, the 
-     * getLocalHost() implementation has changed to always call the 
+     * security problem is resolved.  Also in Connection.java, the
+     * getLocalHost() implementation has changed to always call the
      * InetAddress.getLocalHost().getHostAddress()
      * The above mentioned method has been removed from the connection class
      */
 
-    private static String localHostString = null;
+    private static String localHostString;
 
-    private synchronized String getLocalHostName() 
-    {
+    private synchronized String getLocalHostName() {
         if (localHostString == null) {
             try {
-                localHostString = InetAddress.getLocalHost().getHostAddress();
-            } catch (Exception ex) {
-                throw wrapper.getLocalHostFailed( ex ) ;
+                localHostString = InetAddress.getLocalHost().getHostName();
+            } catch (Exception e) {
+                LOG.log(WARNING, "Failed to resolve local hostname, falling back to loopback. " +
+                    "isLocalHost() checks may be unreliable.", e);
+                localHostString = InetAddress.getLoopbackAddress().getHostName();
             }
         }
-        return localHostString ;
+        return localHostString;
     }
 
  /******************************************************************************

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
@@ -108,7 +108,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock ;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.rmi.CORBA.ValueHandler;
 
@@ -133,6 +133,7 @@ import org.omg.CORBA.ORBPackage.InvalidName;
 import org.omg.CORBA.portable.ValueFactory;
 
 import static com.sun.corba.ee.spi.misc.ORBConstants.SKIP_GMBAL_INIT;
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
@@ -560,6 +561,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
         // other configurators with their own parsers to run,
         // using the same DataCollector.
         try {
+            LOG.log(DEBUG, "Asking configurator {0} to configure me.", configurator);
             configurator.configure( dataCollector, this ) ;
         } catch (Exception exc) {
             throw wrapper.orbConfiguratorError( exc ) ;
@@ -630,8 +632,9 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
     }
 
     @Override
-    public void setParameters( String[] params, Properties props ) {
-        set_parameters( params, props ) ;
+    public void setParameters(String[] params, Properties props) {
+        LOG.log(DEBUG, () -> "setParameters(params=" + Arrays.toString(params) + ", props=" + props + ")");
+        set_parameters(params, props);
     }
 
   /* we can't create object adapters inside the ORB init path, or else we'll get this same problem
@@ -1231,11 +1234,10 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
     }
 
     @Override
-    public org.omg.CORBA.Object resolve_initial_references(
-        String identifier) throws InvalidName {
-        Resolver res ;
-
-        synchronized( this ) {
+    public org.omg.CORBA.Object resolve_initial_references(String identifier) throws InvalidName {
+        LOG.log(DEBUG, "resolve_initial_references(identifier={0})", identifier);
+        Resolver res;
+        synchronized (this) {
             checkShutdownState();
             res = resolver ;
         }
@@ -1252,6 +1254,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
     @Override
     public void register_initial_reference(
         String id, org.omg.CORBA.Object obj ) throws InvalidName {
+        LOG.log(DEBUG, "register_initial_reference(id={0}, obj={1})", id, obj);
         ServerRequestDispatcher insnd ;
 
         if ((id == null) || (id.length() == 0)) {
@@ -1679,8 +1682,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
     }
 
     @Override
-    public synchronized void connect(org.omg.CORBA.Object servant)
-    {
+    public synchronized void connect(org.omg.CORBA.Object servant) {
+        LOG.log(DEBUG, "connect(servant={0})", servant);
         checkShutdownState();
         if (getTOAFactory() == null) {
             throw wrapper.noToa();
@@ -1695,8 +1698,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
     }
 
     @Override
-    public synchronized void disconnect(org.omg.CORBA.Object obj)
-    {
+    public synchronized void disconnect(org.omg.CORBA.Object obj) {
+        LOG.log(DEBUG, "disconnect(obj={0})", obj);
         checkShutdownState();
         if (getTOAFactory() == null) {
             throw wrapper.noToa();
@@ -1775,8 +1778,12 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseab
                  configData.getPersistentServerIdInitialized(), psid ) ;
         }
 
-        if ((subcontractId < ORBConstants.FIRST_POA_SCID) ||
-            (subcontractId > ORBConstants.MAX_POA_SCID)) {
+        LOG.log(DEBUG, "isLocalServerId: params[subcontractId={0}, serverId={1}], mystate[transientServerId={2},"
+            + " persistentServerId={3}, persistentServerIdInitialized={4}]",
+            subcontractId, serverId, getTransientServerId(),
+            configData.getPersistentServerId(), configData.getPersistentServerIdInitialized());
+
+        if (subcontractId < ORBConstants.FIRST_POA_SCID || subcontractId > ORBConstants.MAX_POA_SCID) {
             return serverId == getTransientServerId();
         }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
@@ -47,18 +47,18 @@ import com.sun.corba.ee.impl.protocol.RequestDispatcherRegistryImpl;
 import com.sun.corba.ee.impl.threadpool.ThreadPoolManagerImpl;
 import com.sun.corba.ee.impl.transport.TransportManagerImpl;
 import com.sun.corba.ee.impl.util.Utility;
-import com.sun.corba.ee.spi.copyobject.CopierManager ;
+import com.sun.corba.ee.spi.copyobject.CopierManager;
 import com.sun.corba.ee.spi.ior.IOR;
-import com.sun.corba.ee.spi.ior.IORFactories ;
-import com.sun.corba.ee.spi.ior.IdentifiableFactoryFinder ;
-import com.sun.corba.ee.spi.ior.ObjectKey ;
-import com.sun.corba.ee.spi.ior.ObjectKeyFactory ;
+import com.sun.corba.ee.spi.ior.IORFactories;
+import com.sun.corba.ee.spi.ior.IdentifiableFactoryFinder;
+import com.sun.corba.ee.spi.ior.ObjectKey;
+import com.sun.corba.ee.spi.ior.ObjectKeyFactory;
 import com.sun.corba.ee.spi.ior.TaggedComponentFactoryFinder;
 import com.sun.corba.ee.spi.ior.TaggedProfile;
 import com.sun.corba.ee.spi.ior.TaggedProfileTemplate;
 import com.sun.corba.ee.spi.legacy.connection.LegacyServerSocketManager;
 import com.sun.corba.ee.spi.logging.ORBUtilSystemException;
-import com.sun.corba.ee.spi.misc.ORBConstants ;
+import com.sun.corba.ee.spi.misc.ORBConstants;
 import com.sun.corba.ee.spi.oa.OAInvocationInfo;
 import com.sun.corba.ee.spi.oa.ObjectAdapterFactory;
 import com.sun.corba.ee.spi.orb.DataCollector;
@@ -71,10 +71,10 @@ import com.sun.corba.ee.spi.orb.Operation;
 import com.sun.corba.ee.spi.orb.OperationFactory;
 import com.sun.corba.ee.spi.orb.ParserImplBase;
 import com.sun.corba.ee.spi.orb.PropertyParser;
-import com.sun.corba.ee.spi.presentation.rmi.InvocationInterceptor ;
-import com.sun.corba.ee.spi.presentation.rmi.StubAdapter ;
+import com.sun.corba.ee.spi.presentation.rmi.InvocationInterceptor;
+import com.sun.corba.ee.spi.presentation.rmi.StubAdapter;
 import com.sun.corba.ee.spi.protocol.ClientDelegateFactory;
-import com.sun.corba.ee.spi.protocol.ClientInvocationInfo ;
+import com.sun.corba.ee.spi.protocol.ClientInvocationInfo;
 import com.sun.corba.ee.spi.protocol.PIHandler;
 import com.sun.corba.ee.spi.protocol.RequestDispatcherRegistry;
 import com.sun.corba.ee.spi.protocol.ServerRequestDispatcher;
@@ -91,24 +91,23 @@ import com.sun.corba.ee.spi.transport.TransportManager;
 import com.sun.org.omg.SendingContext.CodeBase;
 
 import java.applet.Applet;
-import java.io.IOException ;
+import java.io.IOException;
 import java.lang.System.Logger;
 import java.lang.reflect.Constructor;
-import java.net.InetAddress ;
-import java.util.ArrayList ;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap ;
-import java.util.HashSet ;
-import java.util.Iterator ;
-import java.util.List ;
-import java.util.Map ;
-import java.util.Properties ;
-import java.util.Set ;
-import java.util.WeakHashMap ;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock ;
 
 import javax.rmi.CORBA.ValueHandler;
@@ -142,74 +141,65 @@ import static java.lang.System.Logger.Level.WARNING;
  */
 @OrbLifeCycle
 @Subcontract
-public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
+public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB implements AutoCloseable {
     private static final Logger LOG = System.getLogger(ORBImpl.class.getName());
-    private boolean set_parameters_called = false ;
+    private boolean set_parameters_called ;
 
-    protected TransportManager transportManager;
-    protected LegacyServerSocketManager legacyServerSocketManager;
+    private TransportManager transportManager;
+    private LegacyServerSocketManager legacyServerSocketManager;
 
-    private ThreadLocal<StackImpl<OAInvocationInfo>>
-        OAInvocationInfoStack ;
-
-    private ThreadLocal<StackImpl<ClientInvocationInfo>>
-        clientInvocationInfoStack ;
+    private ThreadLocal<StackImpl<OAInvocationInfo>> OAInvocationInfoStack;
+    private ThreadLocal<StackImpl<ClientInvocationInfo>> clientInvocationInfoStack;
 
     // pure java orb, caching the servant IOR per ORB
-    private CodeBase codeBase = null ; 
-    private IOR codeBaseIOR = null ;
+    private CodeBase codeBase ;
+    private IOR codeBaseIOR ;
 
     // List holding deferred Requests
-    private final List<Request>  dynamicRequests =
-        new ArrayList<Request>();
-
+    private final List<Request> dynamicRequests = new ArrayList<Request>();
     private final SynchVariable svResponseReceived = new SynchVariable();
-
 
     private final Object runObj = new Object();
     private final Object shutdownObj = new Object();
-    private final AtomicInteger numWaiters = new AtomicInteger() ;
+    private final AtomicInteger numWaiters = new AtomicInteger();
     private final Object waitForCompletionObj = new Object();
     private static final byte STATUS_OPERATING = 1;
     private static final byte STATUS_SHUTTING_DOWN = 2;
     private static final byte STATUS_SHUTDOWN = 3;
     private static final byte STATUS_DESTROYED = 4;
-    private final ReadWriteLock statueLock = new ReentrantReadWriteLock() ;
     private byte status = STATUS_OPERATING;
 
-    private final java.lang.Object invocationObj = new java.lang.Object();
     private AtomicInteger numInvocations = new AtomicInteger();
 
-    // thread local variable to store a boolean to detect deadlock in 
+    // thread local variable to store a boolean to detect deadlock in
     // ORB.shutdown(true).
-    private ThreadLocal<Boolean> isProcessingInvocation = 
-        new ThreadLocal<Boolean> () {
+    private ThreadLocal<Boolean> isProcessingInvocation = new ThreadLocal<Boolean>() {
+
         @Override
-            protected Boolean initialValue() {
-                return false ;
-            }
-        };
+        protected Boolean initialValue() {
+            return false;
+        }
+    };
 
     // This map is caching TypeCodes created for a certain class (key)
     // and is used in Util.writeAny()
-    private Map<Class<?>,TypeCodeImpl> typeCodeForClassMap ;
+    private Map<Class<?>, TypeCodeImpl> typeCodeForClassMap;
 
     // Cache to hold ValueFactories (Helper classes) keyed on repository ids
-    private Map<String,ValueFactory> valueFactoryCache = 
-        new HashMap<String,ValueFactory>();
+    private Map<String, ValueFactory> valueFactoryCache = new HashMap<String, ValueFactory>();
 
     // thread local variable to store the current ORB version.
     // default ORB version is the version of ORB with correct Rep-id
     // changes
-    private ThreadLocal<ORBVersion> orbVersionThreadLocal ; 
+    private ThreadLocal<ORBVersion> orbVersionThreadLocal;
 
-    private RequestDispatcherRegistry requestDispatcherRegistry ;
+    private RequestDispatcherRegistry requestDispatcherRegistry;
 
-    private CopierManager copierManager ;
+    private CopierManager copierManager;
 
-    private int transientServerId ;
+    private int transientServerId;
 
-    private ServiceContextFactoryRegistry serviceContextFactoryRegistry ;
+    private ServiceContextFactoryRegistry serviceContextFactoryRegistry;
 
     private ServiceContextsCache serviceContextsCache;
 
@@ -217,6 +207,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     private ResourceFactory<TOAFactory> toaFactory =
         new ResourceFactory<TOAFactory>(
             new NullaryFunction<TOAFactory>()  {
+                @Override
                 public TOAFactory evaluate() {
                     return (TOAFactory)requestDispatcherRegistry.getObjectAdapterFactory(
                         ORBConstants.TOA_SCID) ;
@@ -228,6 +219,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     private ResourceFactory<POAFactory> poaFactory =
         new ResourceFactory<POAFactory>(
             new NullaryFunction<POAFactory>()  {
+                @Override
                 public POAFactory evaluate() {
                     return (POAFactory)requestDispatcherRegistry.getObjectAdapterFactory(
                         ORBConstants.TRANSIENT_SCID) ;
@@ -237,15 +229,15 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     // The interceptor handler, which provides portable interceptor services for
     // subcontracts and object adapters.
-    private PIHandler pihandler ;
+    private PIHandler pihandler;
 
-    private ORBData configData ;
+    private ORBData configData;
 
-    private BadServerIdHandler badServerIdHandler ;
+    private BadServerIdHandler badServerIdHandler;
 
-    private ClientDelegateFactory clientDelegateFactory ;
+    private ClientDelegateFactory clientDelegateFactory;
 
-    private ContactInfoListFactory corbaContactInfoListFactory ;
+    private ContactInfoListFactory corbaContactInfoListFactory;
 
     // All access to resolver, localResolver, and urlOperation must be protected using
     // the appropriate locks.  Do not hold the ORBImpl lock while accessing
@@ -259,40 +251,32 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     // same lock to access the localResolver.
 
     // Used for resolver_initial_references and list_initial_services
-    private Resolver resolver ;
+    private Resolver resolver;
 
     // Used for register_initial_references
-    private LocalResolver localResolver ;
+    private LocalResolver localResolver;
 
     // ServerRequestDispatcher used for all INS object references.
-    private ServerRequestDispatcher insNamingDelegate ;
+    private ServerRequestDispatcher insNamingDelegate;
 
     // resolverLock must be used for all access to either resolver or
     // localResolver, since it is possible for the resolver to indirectly
-    // refer to the localResolver.  Also used to protect access to
-    // insNamingDelegate.
-    private final Object resolverLock = new Object() ;
+    // refer to the localResolver.  Also used to protect access to insNamingDelegate.
+    private final Object resolverLock = new Object();
 
     // Converts strings to object references for resolvers and string_to_object
     private Operation urlOperation ;
-    private final Object urlOperationLock = new java.lang.Object() ;
+    private final Object urlOperationLock = new java.lang.Object();
 
-    private TaggedComponentFactoryFinder
-        taggedComponentFactoryFinder ;
+    private TaggedComponentFactoryFinder taggedComponentFactoryFinder;
+    private IdentifiableFactoryFinder<TaggedProfile> taggedProfileFactoryFinder;
+    private IdentifiableFactoryFinder<TaggedProfileTemplate> taggedProfileTemplateFactoryFinder;
+    private ObjectKeyFactory objectKeyFactory;
 
-    private IdentifiableFactoryFinder<TaggedProfile>
-        taggedProfileFactoryFinder ;
-
-    private IdentifiableFactoryFinder<TaggedProfileTemplate>
-        taggedProfileTemplateFactoryFinder ;
-
-    private ObjectKeyFactory objectKeyFactory ;
-
-    private boolean orbOwnsThreadPoolManager = false ;
+    private boolean orbOwnsThreadPoolManager = false;
 
     private ThreadPoolManager threadpoolMgr;
-
-    private InvocationInterceptor invocationInterceptor ;
+    private InvocationInterceptor invocationInterceptor;
 
     private WeakCache<ByteArrayWrapper, ObjectKeyCacheEntry> objectKeyCache =
         new WeakCache<ByteArrayWrapper, ObjectKeyCacheEntry> () {
@@ -305,40 +289,30 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             }
         } ;
 
+    @Override
     public InvocationInterceptor getInvocationInterceptor() {
         return invocationInterceptor ;
     }
 
+    @Override
     public void setInvocationInterceptor( InvocationInterceptor interceptor ) {
         this.invocationInterceptor = interceptor ;
     }
-    
-    ////////////////////////////////////////////////////
-    //
-    // NOTE:
-    //
-    // Methods that are synchronized MUST stay synchronized.
-    //
-    // Methods that are NOT synchronized must stay that way to avoid deadlock.
-    //
-    //
-    // REVISIT:
-    //
-    // checkShutDownState - lock on different object - and normalize usage.
-    // starting/FinishDispatch and Shutdown
-    // 
 
-    public ORBData getORBData() 
+    @Override
+    public ORBData getORBData()
     {
         return configData ;
     }
- 
+
+    @Override
     public PIHandler getPIHandler()
     {
         return pihandler ;
     }
 
-    public void createPIHandler() 
+    @Override
+    public void createPIHandler()
     {
         this.pihandler = new PIHandlerImpl( this, configData.getOrbInitArgs() ) ;
     }
@@ -352,11 +326,13 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         // All initialization is done through set_parameters().
     }
 
+    @Override
     public ORBVersion getORBVersion()
     {
         return orbVersionThreadLocal.get() ;
     }
 
+    @Override
     public void setORBVersion(ORBVersion verObj)
     {
         orbVersionThreadLocal.set(verObj);
@@ -382,14 +358,14 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         // Compute transientServerId = milliseconds since Jan 1, 1970
         // Note: transientServerId will wrap in about 2^32 / 86400000 = 49.7 days.
         // If two ORBS are started at the same time then there is a possibility
-        // of having the same transientServerId. This may result in collision 
-        // and may be a problem in ior.isLocal() check to see if the object 
+        // of having the same transientServerId. This may result in collision
+        // and may be a problem in ior.isLocal() check to see if the object
         // belongs to the current ORB. This problem is taken care of by checking
         // to see if the IOR port matches ORB server port in legacyIsLocalServerPort()
         // method.
         transientServerId = (int)System.currentTimeMillis();
 
-        orbVersionThreadLocal  = new ThreadLocal<ORBVersion>() {
+        orbVersionThreadLocal  = new ThreadLocal<>() {
             @Override
             protected ORBVersion initialValue() {
                 // set default to version of the ORB with correct Rep-ids
@@ -397,35 +373,30 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             }
         };
 
-        requestDispatcherRegistry = new RequestDispatcherRegistryImpl( 
-            ORBConstants.DEFAULT_SCID);
-        copierManager = new CopierManagerImpl() ;
+        requestDispatcherRegistry = new RequestDispatcherRegistryImpl(ORBConstants.DEFAULT_SCID);
+        copierManager = new CopierManagerImpl();
 
-        taggedComponentFactoryFinder = 
-            new TaggedComponentFactoryFinderImpl(this) ;
-        taggedProfileFactoryFinder = 
-            new TaggedProfileFactoryFinderImpl(this) ;
-        taggedProfileTemplateFactoryFinder = 
-            new TaggedProfileTemplateFactoryFinderImpl(this) ;
+        taggedComponentFactoryFinder = new TaggedComponentFactoryFinderImpl(this);
+        taggedProfileFactoryFinder = new TaggedProfileFactoryFinderImpl(this);
+        taggedProfileTemplateFactoryFinder = new TaggedProfileTemplateFactoryFinderImpl(this);
 
-        OAInvocationInfoStack = 
-            new ThreadLocal<StackImpl<OAInvocationInfo>> () {
-                @Override
-                protected StackImpl<OAInvocationInfo> initialValue() {
-                    return new StackImpl<OAInvocationInfo>();
-                } 
-            };
+        OAInvocationInfoStack = new ThreadLocal<StackImpl<OAInvocationInfo>>() {
 
-        clientInvocationInfoStack = 
-            new ThreadLocal<StackImpl<ClientInvocationInfo>>() {
-                @Override
-                protected StackImpl<ClientInvocationInfo> initialValue() {
-                    return new StackImpl<ClientInvocationInfo>();
-                }
-            };
+            @Override
+            protected StackImpl<OAInvocationInfo> initialValue() {
+                return new StackImpl<OAInvocationInfo>();
+            }
+        };
 
-        serviceContextFactoryRegistry = 
-            ServiceContextDefaults.makeServiceContextFactoryRegistry( this ) ;
+        clientInvocationInfoStack = new ThreadLocal<StackImpl<ClientInvocationInfo>>() {
+
+            @Override
+            protected StackImpl<ClientInvocationInfo> initialValue() {
+                return new StackImpl<ClientInvocationInfo>();
+            }
+        };
+
+        serviceContextFactoryRegistry = ServiceContextDefaults.makeServiceContextFactoryRegistry(this);
     }
 
     @InfoMethod
@@ -466,7 +437,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
         public ConfigParser( boolean disableORBD ) {
             // Default configurator
-            configurator = ORBConfiguratorImpl.class ;            
+            configurator = ORBConfiguratorImpl.class ;
 
             if (!disableORBD) {
                 // Note: this class is NOT included in the GF bundles!
@@ -481,6 +452,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             }
         }
 
+        @Override
         public PropertyParser makeParser()
         {
             PropertyParser parser = new PropertyParser() ;
@@ -491,7 +463,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
-    // Map String to Integer to count number of ORBs with the 
+    // Map String to Integer to count number of ORBs with the
     // same ORBId.
     private static final Map<String,Integer> idcount =
         new HashMap<String,Integer>() ;
@@ -506,7 +478,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             }
 
             int num = 1 ;
-            // Look up the current count of ORB instances with 
+            // Look up the current count of ORB instances with
             // the same ORBId.  If this is the first instance,
             // the count is 1, otherwise increment the count.
             synchronized (idcount) {
@@ -559,7 +531,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         initializePrimitiveTypeCodeConstants() ;
 
         // REVISIT: this should go away after more transport init cleanup
-        // and going to ORT based ORBD.  
+        // and going to ORT based ORBD.
         transportManager = new TransportManagerImpl(this);
         getLegacyServerSocketManager();
 
@@ -572,18 +544,16 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         ConfigParser parser = new ConfigParser( configData.disableORBD() ) ;
         parser.init( dataCollector ) ;
 
-        ORBConfigurator configurator =  null ;
         String name = "NO NAME AVAILABLE" ;
         if (parser.configurator == null) {
             throw wrapper.badOrbConfigurator( name ) ;
-        } else {
-            try {
-                configurator = 
-                    (ORBConfigurator)(parser.configurator.newInstance()) ;
-            } catch (Exception iexc) {
-                name = parser.configurator.getName() ;
-                throw wrapper.badOrbConfigurator( iexc, name ) ;
-            }
+        }
+        final ORBConfigurator configurator;
+        try {
+            configurator = (ORBConfigurator) (parser.configurator.newInstance());
+        } catch (Exception iexc) {
+            name = parser.configurator.getName() ;
+            throw wrapper.badOrbConfigurator( iexc, name ) ;
         }
 
         // Finally, run the configurator.  Note that the default implementation allows
@@ -597,14 +567,14 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
         userConfiguratorExecutionComplete( getORBData().getORBId()  ) ;
 
-        // Initialize the thread manager pool 
+        // Initialize the thread manager pool
         // so it may be initialized & accessed without synchronization.
-        // This must take place here so that a user conifigurator can 
+        // This must take place here so that a user conifigurator can
         // set the threadpool manager first.
         getThreadPoolManager();
 
         // Last of all, run the ORB initializers.
-        // Interceptors will not be executed until 
+        // Interceptors will not be executed until
         // after pihandler.initialize().  A request that starts before
         // initialize completes and completes after initialize completes does
         // not see any interceptors.
@@ -637,26 +607,29 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     @OrbLifeCycle
     public void set_parameters( Properties props )
     {
         preInit( null, props ) ;
-        DataCollector dataCollector = 
+        DataCollector dataCollector =
             DataCollectorFactory.create( props, getLocalHostName() ) ;
         postInit( null, dataCollector ) ;
         initializationComplete( getORBData().getORBId() ) ;
     }
 
+    @Override
     @OrbLifeCycle
     protected void set_parameters(Applet app, Properties props)
     {
         preInit( null, props ) ;
-        DataCollector dataCollector = 
+        DataCollector dataCollector =
             DataCollectorFactory.create( app, props, getLocalHostName() ) ;
         postInit( null, dataCollector ) ;
         initializationComplete( getORBData().getORBId() ) ;
     }
 
+    @Override
     public void setParameters( String[] params, Properties props ) {
         set_parameters( params, props ) ;
     }
@@ -666,10 +639,11 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
    * Having an IORInterceptor (TxSecIORInterceptor) get called during ORB init always results in a
    * nested ORB.init call because of the call to getORB in the IORInterceptor.
    */
+    @Override
     protected void set_parameters (String[] params, Properties props)
     {
         preInit( params, props ) ;
-        DataCollector dataCollector = 
+        DataCollector dataCollector =
             DataCollectorFactory.create( params, props, getLocalHostName() ) ;
         postInit( params, dataCollector ) ;
     }
@@ -678,6 +652,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
  * The following methods are standard public CORBA ORB APIs
  ****************************************************************************/
 
+    @Override
     public synchronized org.omg.CORBA.portable.OutputStream create_output_stream()
     {
         return OutputStreamFactory.newEncapsOutputStream(this);
@@ -693,6 +668,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @return          a Current pseudo-object.
      * @deprecated
      */
+    @Deprecated
     @Override
     public synchronized org.omg.CORBA.Current get_current()
     {
@@ -704,8 +680,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
            or security ?? Or is it assumed that there is just one
            implementation for both ? If Current is thread-specific,
            then it should not be instantiated; so where does the
-           ORB get a Current ? 
-           
+           ORB get a Current ?
+
            This should probably be deprecated. */
 
         throw wrapper.genericNoImpl() ;
@@ -719,6 +695,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @see NVList
      */
+    @Override
     public synchronized NVList create_list(int count)
     {
         checkShutdownState();
@@ -745,6 +722,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @return          NamedValue created
      */
+    @Override
     public synchronized NamedValue create_named_value(String s, Any any, int flags)
     {
         checkShutdownState();
@@ -756,6 +734,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @return          ExceptionList created
      */
+    @Override
     public synchronized org.omg.CORBA.ExceptionList create_exception_list()
     {
         checkShutdownState();
@@ -767,6 +746,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @return          ContextList created
      */
+    @Override
     public synchronized org.omg.CORBA.ContextList create_context_list()
     {
         checkShutdownState();
@@ -778,6 +758,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @return          the default Context object
      */
+    @Override
     public synchronized org.omg.CORBA.Context get_default_context()
     {
         checkShutdownState();
@@ -789,19 +770,21 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @return          Environment created
      */
+    @Override
     public synchronized org.omg.CORBA.Environment create_environment()
     {
         checkShutdownState();
         return new EnvironmentImpl();
     }
 
+    @Override
     public synchronized void send_multiple_requests_oneway(Request[] req)
     {
         checkShutdownState();
 
         // Invoke the send_oneway on each new Request
-        for (int i = 0; i < req.length; i++) {
-            req[i].send_oneway();
+        for (Request element : req) {
+            element.send_oneway();
         }
     }
 
@@ -810,6 +793,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @param req         an array of request objects.
      */
+    @Override
     public synchronized void send_multiple_requests_deferred(Request[] req)
     {
         checkShutdownState();
@@ -817,7 +801,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
         // Invoke the send_deferred on each new Request
         for (Request r : req) {
-            AsynchInvoke invokeObject = new AsynchInvoke( this, 
+            AsynchInvoke invokeObject = new AsynchInvoke( this,
                 (com.sun.corba.ee.impl.corba.RequestImpl)r, true);
             new Thread(invokeObject).start();
         }
@@ -826,6 +810,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     /**
      * Find out if any of the deferred invocations have a response yet.
      */
+    @Override
     public synchronized boolean poll_next_response()
     {
         checkShutdownState();
@@ -846,6 +831,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @return            the next request ready with a response.
      */
+    @Override
     public org.omg.CORBA.Request get_next_response()
         throws org.omg.CORBA.WrongTransaction
     {
@@ -885,7 +871,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     /**
      * Notify response to ORB for get_next_response
      */
-    public void notifyORB() 
+    @Override
+    public void notifyORB()
     {
         synchronized (this.svResponseReceived) {
             this.svResponseReceived.set();
@@ -898,6 +885,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param obj The object to stringify.
      * @return A stringified object reference.
      */
+    @Override
     public synchronized String object_to_string(org.omg.CORBA.Object obj)
     {
         checkShutdownState();
@@ -929,6 +917,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param str The stringified object reference.
      * @return The unstringified object reference.
      */
+    @Override
     public org.omg.CORBA.Object string_to_object(String str)
     {
         Operation op ;
@@ -950,6 +939,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     // pure java orb support, moved this method from FVDCodeBaseImpl.
     // Note that we connect this if we have not already done so.
+    @Override
     public synchronized IOR getFVDCodeBaseIOR()
     {
         if (codeBaseIOR == null) {
@@ -967,8 +957,9 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param tcKind    the integer kind for the primitive type
      * @return          the requested TypeCode
      */
+    @Override
     public TypeCode get_primitive_tc(TCKind tcKind) {
-        return get_primitive_tc( tcKind.value() ) ; 
+        return get_primitive_tc( tcKind.value() ) ;
     }
 
     /**
@@ -979,6 +970,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param members   an array describing the members of the TypeCode.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_struct_tc(String id,
                                      String name,
                                      StructMember[] members)
@@ -997,6 +989,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param members   an array describing the members of the TypeCode.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_union_tc(String id,
                                     String name,
                                     TypeCode discriminator_type,
@@ -1019,6 +1012,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param members   an array describing the members of the TypeCode.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_enum_tc(String id,
                                    String name,
                                    String[] members)
@@ -1036,6 +1030,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *                  the type this is an alias for.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_alias_tc(String id,
                                     String name,
                                     TypeCode original_type)
@@ -1052,6 +1047,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param members   an array describing the members of the TypeCode.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_exception_tc(String id,
                                         String name,
                                         StructMember[] members)
@@ -1067,6 +1063,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param name      the name for the typecode.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_interface_tc(String id,
                                         String name)
     {
@@ -1080,6 +1077,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param bound     the bound for the string.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_string_tc(int bound)
     {
         checkShutdownState();
@@ -1092,12 +1090,14 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param bound     the bound for the string.
      * @return          the requested TypeCode.
      */
+    @Override
     public synchronized TypeCode create_wstring_tc(int bound) {
         checkShutdownState();
         return new TypeCodeImpl(this, TCKind._tk_wstring, bound);
     }
 
-    public synchronized TypeCode create_sequence_tc(int bound, 
+    @Override
+    public synchronized TypeCode create_sequence_tc(int bound,
         TypeCode element_type) {
 
         checkShutdownState();
@@ -1105,6 +1105,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     }
 
 
+    @Override
     @SuppressWarnings("deprecation")
     public synchronized TypeCode create_recursive_sequence_tc(int bound,
                                                  int offset) {
@@ -1113,6 +1114,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     }
 
 
+    @Override
     public synchronized TypeCode create_array_tc(int length,
                                     TypeCode element_type)
     {
@@ -1169,10 +1171,11 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
                                                       TypeCode boxed_type)
     {
         checkShutdownState();
-        return new TypeCodeImpl(this, TCKind._tk_value_box, id, name, 
+        return new TypeCodeImpl(this, TCKind._tk_value_box, id, name,
             boxed_type);
     }
 
+    @Override
     public synchronized Any create_any()
     {
         checkShutdownState();
@@ -1185,7 +1188,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     // Keeping a cache of TypeCodes associated with the class
     // they got created from in Util.writeAny().
 
-    public synchronized void setTypeCodeForClass(Class c, TypeCodeImpl tci) 
+    @Override
+    public synchronized void setTypeCodeForClass(Class c, TypeCodeImpl tci)
     {
         if (typeCodeForClassMap == null) {
             typeCodeForClassMap = new WeakHashMap<Class<?>, TypeCodeImpl>(64);
@@ -1197,7 +1201,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
-    public synchronized TypeCodeImpl getTypeCodeForClass(Class c) 
+    @Override
+    public synchronized TypeCodeImpl getTypeCodeForClass(Class c)
     {
         if (typeCodeForClassMap == null) {
             return null;
@@ -1210,6 +1215,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
  * (bootstrap) object references such as "NameService".
  ****************************************************************************/
 
+    @Override
     public String[] list_initial_services() {
         Resolver res ;
 
@@ -1224,6 +1230,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     public org.omg.CORBA.Object resolve_initial_references(
         String identifier) throws InvalidName {
         Resolver res ;
@@ -1234,7 +1241,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
 
         org.omg.CORBA.Object result = res.resolve( identifier ) ;
-        
+
         if (result == null) {
             throw new InvalidName(identifier + " not found");
         } else {
@@ -1263,10 +1270,10 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
                 throw new InvalidName(id + " already registered");
             }
 
-            localResolver.register( id, 
+            localResolver.register( id,
                 NullaryFunction.Factory.makeConstant( obj )) ;
         }
-      
+
         synchronized (this) {
             if (StubAdapter.isStub(obj)) {
                 requestDispatcherRegistry.registerServerRequestDispatcher(insnd, id);
@@ -1280,7 +1287,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
  ****************************************************************************/
 
     @Override
-    public void run() 
+    public void run()
     {
         synchronized (this) {
             checkShutdownState();
@@ -1300,8 +1307,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
         synchronized (this) {
             checkShutdownState();
-            
-            // This is to avoid deadlock: don't allow a thread that is 
+
+            // This is to avoid deadlock: don't allow a thread that is
             // processing a request to call shutdown( true ), because
             // the shutdown would block waiting for the request to complete,
             // while the request would block waiting for shutdown to complete.
@@ -1319,7 +1326,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             }
 
             status = STATUS_SHUTTING_DOWN ;
-        } 
+        }
 
         // Avoid more than one thread performing shutdown at a time.
         synchronized (shutdownObj) {
@@ -1342,7 +1349,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
                 }
             } else {
                 startingShutdown( getORBData().getORBId() ) ;
-                
+
                 // perform the actual shutdown
                 shutdownServants(wait_for_completion);
 
@@ -1372,14 +1379,14 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
-    // Cause all ObjectAdapaterFactories to clean up all of their internal state, which 
+    // Cause all ObjectAdapaterFactories to clean up all of their internal state, which
     // may include activated objects that have associated state and callbacks that must
     // complete in order to shutdown.  This will cause new request to be rejected.
     @OrbLifeCycle
     protected void shutdownServants(boolean wait_for_completion) {
         Set<ObjectAdapterFactory> oaset ;
         synchronized(this) {
-            oaset = new HashSet<ObjectAdapterFactory>( 
+            oaset = new HashSet<ObjectAdapterFactory>(
                 requestDispatcherRegistry.getObjectAdapterFactories() ) ;
         }
 
@@ -1400,15 +1407,18 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     public boolean isDuringDispatch() {
         return isProcessingInvocation.get() ;
     }
 
+    @Override
     public void startingDispatch() {
         isProcessingInvocation.set(true);
         numInvocations.incrementAndGet() ;
     }
 
+    @Override
     public void finishedDispatch() {
         isProcessingInvocation.set(false);
         int ni = numInvocations.decrementAndGet() ;
@@ -1421,6 +1431,14 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
                 waitForCompletionObj.notifyAll();
             }
         }
+    }
+
+    /**
+     * Calls {@link #destroy()}
+     */
+    @Override
+    public void close() throws Exception {
+        destroy();
     }
 
     /**
@@ -1481,21 +1499,21 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         super.destroy() ;
 
         synchronized (this) {
-            corbaContactInfoListFactoryAccessLock = null ; 
+            corbaContactInfoListFactoryAccessLock = null ;
             corbaContactInfoListFactoryReadLock = null ;
             corbaContactInfoListFactoryWriteLock = null ;
 
             transportManager = null ;
             legacyServerSocketManager = null ;
-            OAInvocationInfoStack  = null ; 
-            clientInvocationInfoStack  = null ; 
-            codeBase = null ; 
+            OAInvocationInfoStack  = null ;
+            clientInvocationInfoStack  = null ;
+            codeBase = null ;
             codeBaseIOR = null ;
             dynamicRequests.clear() ;
             isProcessingInvocation = null ;
             typeCodeForClassMap  = null ;
             valueFactoryCache = null ;
-            orbVersionThreadLocal = null ; 
+            orbVersionThreadLocal = null ;
             requestDispatcherRegistry = null ;
             copierManager = null ;
             serviceContextFactoryRegistry = null ;
@@ -1531,13 +1549,13 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      *
      * @param repositoryID the repository ID.
      * @param factory the factory.
-     * @return the previously registered factory for the given repository ID, 
+     * @return the previously registered factory for the given repository ID,
      * or null if no such factory was previously registered.
      * @exception org.omg.CORBA.BAD_PARAM if the registration fails.
      **/
     @Override
-    public synchronized ValueFactory register_value_factory(String repositoryID, 
-        ValueFactory factory) 
+    public synchronized ValueFactory register_value_factory(String repositoryID,
+        ValueFactory factory)
     {
         checkShutdownState();
 
@@ -1554,7 +1572,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @param repositoryID the repository ID.
      **/
     @Override
-    public synchronized void unregister_value_factory(String repositoryID) 
+    public synchronized void unregister_value_factory(String repositoryID)
     {
         checkShutdownState();
 
@@ -1573,7 +1591,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
      * @exception org.omg.CORBA.BAD_PARAM if unable to locate a factory.
      **/
     @Override
-    public synchronized ValueFactory lookup_value_factory(String repositoryID) 
+    public synchronized ValueFactory lookup_value_factory(String repositoryID)
     {
         checkShutdownState();
 
@@ -1590,14 +1608,17 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         return factory ;
     }
 
+    @Override
     public OAInvocationInfo peekInvocationInfo() {
         return OAInvocationInfoStack.get().peek() ;
     }
 
+    @Override
     public void pushInvocationInfo( OAInvocationInfo info ) {
         OAInvocationInfoStack.get().push( info ) ;
     }
 
+    @Override
     public OAInvocationInfo popInvocationInfo() {
         return OAInvocationInfoStack.get().pop() ;
     }
@@ -1609,7 +1630,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     private final Object badServerIdHandlerAccessLock = new Object();
 
-    public void initBadServerIdHandler() 
+    @Override
+    public void initBadServerIdHandler()
     {
         synchronized (badServerIdHandlerAccessLock) {
             Class<?> cls = configData.getBadServerIdHandler() ;
@@ -1618,7 +1640,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
                     Class<?>[] params = new Class<?>[] { org.omg.CORBA.ORB.class };
                     java.lang.Object[] args = new java.lang.Object[]{this};
                     Constructor<?> cons = cls.getConstructor(params);
-                    badServerIdHandler = 
+                    badServerIdHandler =
                         (BadServerIdHandler) cons.newInstance(args);
                 } catch (Exception e) {
                     throw wrapper.errorInitBadserveridhandler( e ) ;
@@ -1627,14 +1649,16 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
-    public void setBadServerIdHandler( BadServerIdHandler handler ) 
+    @Override
+    public void setBadServerIdHandler( BadServerIdHandler handler )
     {
         synchronized (badServerIdHandlerAccessLock) {
             badServerIdHandler = handler;
         }
     }
 
-    public void handleBadServerId( ObjectKey okey ) 
+    @Override
+    public void handleBadServerId( ObjectKey okey )
     {
         synchronized (badServerIdHandlerAccessLock) {
             if (badServerIdHandler == null) {
@@ -1646,7 +1670,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     }
 
     @Override
-    public synchronized org.omg.CORBA.Policy create_policy( int type, 
+    public synchronized org.omg.CORBA.Policy create_policy( int type,
         org.omg.CORBA.Any val ) throws org.omg.CORBA.PolicyError
     {
         checkShutdownState() ;
@@ -1685,6 +1709,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     public int getTransientServerId()
     {
         if( configData.getPersistentServerIdInitialized( ) ) {
@@ -1694,17 +1719,20 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         return transientServerId;
     }
 
+    @Override
     public RequestDispatcherRegistry getRequestDispatcherRegistry()
     {
         return requestDispatcherRegistry;
     }
 
+    @Override
     public ServiceContextFactoryRegistry getServiceContextFactoryRegistry()
     {
         return serviceContextFactoryRegistry ;
-    } 
+    }
 
-    public ServiceContextsCache getServiceContextsCache() 
+    @Override
+    public ServiceContextsCache getServiceContextsCache()
     {
         return serviceContextsCache;
     }
@@ -1731,6 +1759,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         return ip.equals(configData.getORBServerHost()) || ip.equals(getLocalHostName());
     }
 
+    @Override
     @Subcontract
     public boolean isLocalServerId( int subcontractId, int serverId )
     {
@@ -1740,17 +1769,17 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
                 psid = configData.getPersistentServerId();
             }
 
-            isLocalServerIdInfo( subcontractId, serverId, 
-                 getTransientServerId(), 
+            isLocalServerIdInfo( subcontractId, serverId,
+                 getTransientServerId(),
                  ORBConstants.isTransient(subcontractId),
                  configData.getPersistentServerIdInitialized(), psid ) ;
         }
 
-        if ((subcontractId < ORBConstants.FIRST_POA_SCID) || 
+        if ((subcontractId < ORBConstants.FIRST_POA_SCID) ||
             (subcontractId > ORBConstants.MAX_POA_SCID)) {
             return serverId == getTransientServerId();
         }
-                
+
         // XXX isTransient info should be stored in subcontract registry
         if (ORBConstants.isTransient( subcontractId )) {
             return serverId == getTransientServerId();
@@ -1790,7 +1819,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     }
 
  /******************************************************************************
- *  The following public methods are for ORB shutdown. 
+ *  The following public methods are for ORB shutdown.
  *
  ******************************************************************************/
 
@@ -1803,7 +1832,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         checkShutdownState();
         throw wrapper.genericNoImpl() ;
     }
-  
+
     /** This method does nothing. It is not required by the spec to do anything!
      */
     @Override
@@ -1828,6 +1857,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
     @InfoMethod
     private void invocationInfoChange( String msg ) { }
 
+    @Override
     @Subcontract
     public ClientInvocationInfo createOrIncrementInvocationInfo() {
         ClientInvocationInfo clientInvocationInfo = null;
@@ -1851,7 +1881,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         clientInvocationInfo.incrementEntryCount();
         return clientInvocationInfo;
     }
-    
+
+    @Override
     @Subcontract
     public void releaseOrDecrementInvocationInfo() {
         int entryCount = -1;
@@ -1874,7 +1905,8 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             invocationInfoChange( "pop" ) ;
         }
     }
-    
+
+    @Override
     public ClientInvocationInfo getInvocationInfo() {
         return clientInvocationInfoStack.get().peek() ;
     }
@@ -1886,27 +1918,30 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     private final Object clientDelegateFactoryAccessorLock = new Object();
 
-    public void setClientDelegateFactory( ClientDelegateFactory factory ) 
+    @Override
+    public void setClientDelegateFactory( ClientDelegateFactory factory )
     {
         synchronized (clientDelegateFactoryAccessorLock) {
             clientDelegateFactory = factory ;
         }
     }
 
-    public ClientDelegateFactory getClientDelegateFactory() 
+    @Override
+    public ClientDelegateFactory getClientDelegateFactory()
     {
         synchronized (clientDelegateFactoryAccessorLock) {
             return clientDelegateFactory ;
         }
     }
 
-    private ReentrantReadWriteLock 
+    private ReentrantReadWriteLock
           corbaContactInfoListFactoryAccessLock = new ReentrantReadWriteLock();
     private Lock corbaContactInfoListFactoryReadLock =
                                corbaContactInfoListFactoryAccessLock.readLock();
-    private Lock corbaContactInfoListFactoryWriteLock = 
+    private Lock corbaContactInfoListFactoryWriteLock =
                               corbaContactInfoListFactoryAccessLock.writeLock();
-    
+
+    @Override
     public void setCorbaContactInfoListFactory( ContactInfoListFactory factory )
     {
         corbaContactInfoListFactoryWriteLock.lock() ;
@@ -1917,6 +1952,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     public ContactInfoListFactory getCorbaContactInfoListFactory()
     {
         corbaContactInfoListFactoryReadLock.lock() ;
@@ -1927,57 +1963,67 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     public void setResolver( Resolver resolver ) {
         synchronized (resolverLock) {
             this.resolver = resolver ;
         }
     }
 
+    @Override
     public Resolver getResolver() {
         synchronized (resolverLock) {
             return resolver ;
         }
     }
 
+    @Override
     public void setLocalResolver( LocalResolver resolver ) {
         synchronized (resolverLock) {
             this.localResolver = resolver ;
         }
     }
 
+    @Override
     public LocalResolver getLocalResolver() {
         synchronized (resolverLock) {
             return localResolver ;
         }
     }
 
+    @Override
     public void setURLOperation( Operation stringToObject ) {
         synchronized (urlOperationLock) {
             urlOperation = stringToObject ;
         }
     }
 
+    @Override
     public Operation getURLOperation() {
         synchronized (urlOperationLock) {
             return urlOperation ;
         }
     }
 
+    @Override
     public void setINSDelegate( ServerRequestDispatcher sdel ) {
         synchronized (resolverLock) {
             insNamingDelegate = sdel ;
         }
     }
 
+    @Override
     public TaggedComponentFactoryFinder getTaggedComponentFactoryFinder() {
         return taggedComponentFactoryFinder ;
     }
 
+    @Override
     public IdentifiableFactoryFinder<TaggedProfile>
         getTaggedProfileFactoryFinder() {
         return taggedProfileFactoryFinder ;
     }
 
+    @Override
     public IdentifiableFactoryFinder<TaggedProfileTemplate>
         getTaggedProfileTemplateFactoryFinder() {
         return taggedProfileTemplateFactoryFinder ;
@@ -1985,25 +2031,29 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     private final Object objectKeyFactoryAccessLock = new Object();
 
-    public ObjectKeyFactory getObjectKeyFactory() 
+    @Override
+    public ObjectKeyFactory getObjectKeyFactory()
     {
         synchronized (objectKeyFactoryAccessLock) {
             return objectKeyFactory ;
         }
     }
 
-    public void setObjectKeyFactory( ObjectKeyFactory factory ) 
+    @Override
+    public void setObjectKeyFactory( ObjectKeyFactory factory )
     {
         synchronized (objectKeyFactoryAccessLock) {
             objectKeyFactory = factory ;
         }
     }
 
+    @Override
     public TransportManager getTransportManager()
     {
         return transportManager;
     }
 
+    @Override
     public TransportManager getCorbaTransportManager()
     {
         return getTransportManager();
@@ -2011,6 +2061,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     private final Object legacyServerSocketManagerAccessLock = new Object();
 
+    @Override
     public LegacyServerSocketManager getLegacyServerSocketManager()
     {
         synchronized (legacyServerSocketManagerAccessLock) {
@@ -2023,12 +2074,14 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     private final Object threadPoolManagerAccessLock = new Object();
 
+    @Override
     public void setThreadPoolManager(ThreadPoolManager mgr) {
         synchronized (threadPoolManagerAccessLock) {
             threadpoolMgr = mgr;
         }
     }
 
+    @Override
     public ThreadPoolManager getThreadPoolManager() {
         synchronized (threadPoolManagerAccessLock) {
             if (threadpoolMgr == null) {
@@ -2039,6 +2092,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
         }
     }
 
+    @Override
     public CopierManager getCopierManager() {
         return copierManager ;
     }
@@ -2067,10 +2121,10 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
             // Let any exceptions propagate out
             result = getIOR( obj ) ;
         }
-    
+
         return result ;
     }
-    
+
     @Override
     public ObjectKeyCacheEntry extractObjectKeyCacheEntry(byte[] objKey) {
         if (objKey == null) {
@@ -2084,7 +2138,7 @@ public class ORBImpl extends com.sun.corba.ee.spi.orb.ORB {
 
     @Override
     public synchronized boolean orbIsShutdown() {
-        return ((status == STATUS_DESTROYED) || 
+        return ((status == STATUS_DESTROYED) ||
             (status == STATUS_SHUTDOWN)) ;
     }
 } // Class ORBImpl

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/ServerRequestDispatcherImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/ServerRequestDispatcherImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998-1999 IBM Corp. All rights reserved.
  *
@@ -34,7 +35,6 @@ import com.sun.corba.ee.spi.ior.ObjectKey;
 import com.sun.corba.ee.spi.ior.ObjectKeyTemplate;
 import com.sun.corba.ee.spi.ior.iiop.GIOPVersion;
 import com.sun.corba.ee.spi.logging.ORBUtilSystemException;
-import com.sun.corba.ee.spi.logging.POASystemException;
 import com.sun.corba.ee.spi.oa.NullServant;
 import com.sun.corba.ee.spi.oa.OADestroyed;
 import com.sun.corba.ee.spi.oa.OAInvocationInfo;
@@ -58,6 +58,8 @@ import com.sun.corba.ee.spi.servicecontext.UEInfoServiceContext;
 import com.sun.corba.ee.spi.trace.Subcontract;
 import com.sun.corba.ee.spi.transport.Connection;
 
+import java.lang.System.Logger;
+
 import org.glassfish.pfl.basic.logex.OperationTracer;
 import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
 import org.omg.CORBA.Any;
@@ -69,14 +71,13 @@ import org.omg.CORBA.portable.InvokeHandler;
 import org.omg.CORBA.portable.OutputStream;
 import org.omg.CORBA.portable.UnknownException;
 
+import static java.lang.System.Logger.Level.DEBUG;
+
 @Subcontract
-public class ServerRequestDispatcherImpl
-    implements ServerRequestDispatcher
-{
-    private static final ORBUtilSystemException wrapper =
-        ORBUtilSystemException.self ;
-    private static final POASystemException poaWrapper =
-        POASystemException.self ;
+public class ServerRequestDispatcherImpl implements ServerRequestDispatcher {
+
+    private static final Logger LOG = System.getLogger(ServerRequestDispatcherImpl.class.getName());
+    private static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
 
     protected ORB orb; // my ORB instance
 
@@ -307,6 +308,7 @@ public class ServerRequestDispatcherImpl
     @Subcontract
     protected void checkServerId(ObjectKey okey) {
         ObjectKeyTemplate oktemp = okey.getTemplate() ;
+        LOG.log(DEBUG, () -> "Checking server ID for " + oktemp);
         int sId = oktemp.getServerId() ;
         int scid = oktemp.getSubcontractId() ;
 

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/resolver/LocalResolverImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/resolver/LocalResolverImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -21,6 +22,7 @@ package com.sun.corba.ee.impl.resolver ;
 
 import com.sun.corba.ee.spi.resolver.LocalResolver ;
 
+import java.lang.System.Logger;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -28,12 +30,18 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.pfl.basic.func.NullaryFunction;
 
-public class LocalResolverImpl implements LocalResolver {
-    ConcurrentHashMap<String,NullaryFunction<org.omg.CORBA.Object>> nameToClosure =
-        new ConcurrentHashMap<String,NullaryFunction<org.omg.CORBA.Object>>() ;
-    final Lock lock = new ReentrantLock();
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.TRACE;
 
+public class LocalResolverImpl implements LocalResolver {
+    private static final Logger LOG = System.getLogger(LocalResolverImpl.class.getName());
+
+    private final ConcurrentHashMap<String, NullaryFunction<org.omg.CORBA.Object>> nameToClosure = new ConcurrentHashMap<>();
+    private final Lock lock = new ReentrantLock();
+
+    @Override
     public org.omg.CORBA.Object resolve(String name) {
+        LOG.log(TRACE, "resolve(name={0})", name);
         do {
             try {
                 if (lock.tryLock(500, TimeUnit.MILLISECONDS)) {
@@ -42,25 +50,25 @@ public class LocalResolverImpl implements LocalResolver {
                         if (cl == null) {
                             return null;
                         }
-                        return (org.omg.CORBA.Object) (cl.evaluate());
+                        return cl.evaluate();
                     } finally {
                         lock.unlock();
                     }
-                } else {
-                    // continue, try again
                 }
             } catch (InterruptedException e) {
-                // do nothing
+                Thread.currentThread().interrupt();
             }
         } while (true);
     }
 
+    @Override
     public java.util.Set<String> list() {
         return nameToClosure.keySet() ;
     }
 
-    public void register( String name,
-        NullaryFunction<org.omg.CORBA.Object> closure ) {
-        nameToClosure.put( name, closure ) ;
+    @Override
+    public void register(String name, NullaryFunction<org.omg.CORBA.Object> closure) {
+        LOG.log(DEBUG, "register(name={0}, closure={1})", name, closure);
+        nameToClosure.put(name, closure);
     }
 }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/AcceptorBase.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/AcceptorBase.java
@@ -217,11 +217,9 @@ public abstract class AcceptorBase
 
     @Override
     public String toString() {
-        return toStringName() + "[" + port + " " + type + " " + shouldUseSelectThreadToWait() + " " + shouldUseWorkerThreadForEvent() + "]";
-    }
-
-    protected String toStringName() {
-        return "SocketOrChannelAcceptorImpl";
+        return getClass().getName() + "[orb=" + orb + ", host:port=" + getHost() + ":" + getPort()
+            + ", shouldUseSelectThreadToWait=" + shouldUseSelectThreadToWait()
+            + ", shouldUseWorkerThreadForEvent=" + shouldUseWorkerThreadForEvent() + "]";
     }
 
     public String getHost() {

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/EventHandlerBase.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/EventHandlerBase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -128,6 +129,10 @@ public abstract class EventHandlerBase
     {
         return work;
     }
-}
 
-// End of file.
+    @Override
+    public String toString() {
+        return getClass().getName() + "[orb=" + orb + ", shouldUseSelectThreadToWait=" + shouldUseSelectThreadToWait()
+            + ", shouldUseWorkerThreadForEvent" + shouldUseWorkerThreadForEvent() + "]";
+    }
+}

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/transport/IORToSocketInfo.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/transport/IORToSocketInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -23,15 +24,12 @@ import com.sun.corba.ee.spi.ior.IOR;
 
 import java.util.List;
 
-public interface IORToSocketInfo
-{
-    /** Used to extract socket address information from an IOR.
+public interface IORToSocketInfo {
+    /**
+     * Used to extract socket address information from an IOR.
      * @param ior The ior from which the socket info is extracted.
      * @param previous The previous list, which may be reused if not null.
      * @return a list of SocketInfo.
      */
-    public List<? extends SocketInfo> getSocketInfo(IOR ior, 
-        List<? extends SocketInfo> previous);
+    List<? extends SocketInfo> getSocketInfo(IOR ior, List<? extends SocketInfo> previous);
 }
-
-// End of file.


### PR DESCRIPTION
* I spent four days to fix the last failing tests on https://github.com/eclipse-ee4j/glassfish/pull/25804 comparing logs of original state and my PR in a hope I will find the last side effect I could not find.
* I also noticed few other issues I have seen in GF in last weeks.
    * Local host name resolution was strict, localhost was not accepted as local.
    * ignorance of `InterruptedException`

The initialization is heavily dependent on the order of operations, part is done from GlassFish, another is sparked from `setParameters` method call and finished by PEORBConfigurator. I would like to make it more robust in the future, but I need to know perfectly the required order of operations.

The #288 should be merged first!
