### PR TITLE
Moduleinfo improvements

### DIFF
--- a/orbmain/src/main/java/module-info.java
+++ b/orbmain/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module org.glassfish.corba.orb {
     requires java.sql;
 
     requires org.glassfish.corba.internal;
-    requires org.glassfish.corba.omgapi;
+    requires transitive org.glassfish.corba.omgapi;
 
     requires org.glassfish.external.management.api;
 

--- a/orbmain/src/main/java/module-info.java
+++ b/orbmain/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,6 +41,7 @@ module org.glassfish.corba.orb {
     exports com.sun.corba.ee.impl.legacy.connection;
     exports com.sun.corba.ee.impl.orb;
     exports com.sun.corba.ee.impl.util;
+    exports com.sun.corba.ee.spi.ior;
     exports com.sun.corba.ee.spi.ior.iiop;
     exports com.sun.corba.ee.spi.transport;
 
@@ -48,5 +49,4 @@ module org.glassfish.corba.orb {
     opens com.sun.corba.ee.impl.oa.toa;
     opens com.sun.corba.ee.spi.ior;
     opens com.sun.corba.ee.spi.orb;
-
 }


### PR DESCRIPTION
* IOR is referred in API, must be exported too
* The omgapi is a transitive dependency used in APIs, should be transitive