### PR TITLE
Fixed getLatestVersion() sometimes using wrong field

### DIFF
--- a/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
+++ b/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
@@ -87,7 +87,7 @@ public class AsmClassFactory implements ClassDefinitionFactory {
             }
             return latest;
         } catch (IllegalAccessException e) {
-            return Opcodes.V11;
+            return Opcodes.V17;
         }
     }
 

--- a/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
+++ b/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -68,7 +69,7 @@ public class AsmClassFactory implements ClassDefinitionFactory {
             }
             return latest;
         } catch (IllegalAccessException e) {
-            return Opcodes.ASM7;
+            return Opcodes.ASM9;
         }
     }
 

--- a/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
+++ b/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.glassfish.rmic.Names;
 import org.glassfish.rmic.tools.java.ClassDeclaration;
@@ -51,7 +52,9 @@ public class AsmClassFactory implements ClassDefinitionFactory {
     private Map<Identifier, Identifier> outerClasses = new HashMap<>();
 
     public AsmClassFactory() {
-        if (simulateMissingASM) throw new NoClassDefFoundError();
+        if (simulateMissingASM) {
+            throw new NoClassDefFoundError();
+        }
     }
 
     /**
@@ -80,8 +83,11 @@ public class AsmClassFactory implements ClassDefinitionFactory {
     static int getLatestClassVersion() {
         try {
             int latest = 0;
+            Pattern versionsPattern = Pattern.compile("V[0-9]+");
             for (Field field : Opcodes.class.getDeclaredFields()) {
-                if (!field.getName().equals("V1_1") && field.getName().startsWith("V") && field.getType().equals(int.class)) {
+                if (versionsPattern.matcher(field.getName()).matches()
+                    && field.getName().startsWith("V")
+                    && field.getType().equals(int.class)) {
                     latest = Math.max(latest, field.getInt(Opcodes.class));
                 }
             }
@@ -92,8 +98,9 @@ public class AsmClassFactory implements ClassDefinitionFactory {
     }
 
     Identifier getOuterClassName(Identifier className) {
-        if (isResolvedInnerClassName(className))
+        if (isResolvedInnerClassName(className)) {
             className = Names.mangleClass(className);
+        }
         return outerClasses.get(className);
     }
 
@@ -136,8 +143,9 @@ public class AsmClassFactory implements ClassDefinitionFactory {
 
         private String toSourceFileName(String name) {
             String className = toClassName(name);
-            if (className.contains("$"))
+            if (className.contains("$")) {
                 className = className.substring(0, className.indexOf("$"));
+            }
             return className + ".java";
         }
 
@@ -147,8 +155,9 @@ public class AsmClassFactory implements ClassDefinitionFactory {
 
         private ClassDeclaration[] toClassDeclarations(String... names) {
             ClassDeclaration[] result = new ClassDeclaration[names.length];
-            for (int i = 0; i < names.length; i++)
+            for (int i = 0; i < names.length; i++) {
                 result[i] = new ClassDeclaration(getIdentifier(names[i]));
+            }
             return result;
         }
 
@@ -162,8 +171,9 @@ public class AsmClassFactory implements ClassDefinitionFactory {
 
         @Override
         public void visitInnerClass(String name, String outerName, String innerName, int access) {
-            if (outerName != null)
+            if (outerName != null) {
                 outerClasses.put(getIdentifier(name), getIdentifier(outerName));
+            }
         }
 
         @Override

--- a/rmic/src/test/java/org/glassfish/rmic/asm/AsmClassFactoryTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/asm/AsmClassFactoryTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,6 @@ import org.objectweb.asm.Opcodes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 
 public class AsmClassFactoryTest extends ClassDefinitionFactoryTest {
 
@@ -41,6 +40,6 @@ public class AsmClassFactoryTest extends ClassDefinitionFactoryTest {
 
     @Test
     public void canRetrieveLatestSupportedClassVersion() {
-        assertThat(AsmClassFactory.getLatestClassVersion(), greaterThan(Opcodes.V25));
+        assertThat(AsmClassFactory.getLatestClassVersion(), equalTo(Opcodes.V26));
     }
 }


### PR DESCRIPTION
* Fixed #109 
* The reflection was too permissive and sometimes could use preview or experimental Java version.
* I also updated returned versions so they would reflect our dependencies.