### PR TITLE
Released 5.0.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-        sh 'mvn -Pstaging,all-tests,dash-licenses clean install'
+        sh 'mvn -Psnapshots,all-tests,dash-licenses clean install'
         junit testResults: '**/target/surefire-reports/*.xml', allowEmptyResults: true
         archiveArtifacts artifacts: 'dash-summary.txt'
 

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,28 +69,6 @@
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <name>Disabled Sonatype Nexus</name>
-            <url>http://localhost</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <name>Disabled Sonatype Nexus</name>
-            <url>http://localhost</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
         <site>
             <id>github</id>
             <url>scm:git:https://github.com/eclipse-ee4j/orb.git</url>
@@ -424,33 +402,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
-                    <configuration>
-                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>injected-nexus-deploy</id>
-                            <phase>none</phase>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.central</groupId>
-                    <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.10.0</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <autoPublish>true</autoPublish>
-                        <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
-                        <deploymentName>GlassFish ORB ${project.version}</deploymentName>
-                        <publishingServerId>central</publishingServerId>
-                        <waitUntil>published</waitUntil>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.1</version>
@@ -537,35 +488,10 @@
             <properties>
                 <!-- Until we fix everything -->
                 <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-                <release.projectName>Eclipse GlassFish Corba</release.projectName>
+                <release.projectName>Eclipse GlassFish ORB</release.projectName>
                 <release.autoPublish>false</release.autoPublish>
                 <release.waitUntil>published</release.waitUntil>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.cyclonedx</groupId>
-                        <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <configuration>
-                            <!-- Without this it doesn't generate cyclonedx files at all. -->
-                            <skipNotDeployed>false</skipNotDeployed>
-                        </configuration>
-                    </plugin>
-                    <!-- We have to override settings from parent -->
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <autoPublish>${release.autoPublish}</autoPublish>
-                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
-                            <deploymentName>${release.projectName} ${project.version}</deploymentName>
-                            <publishingServerId>central</publishingServerId>
-                            <waitUntil>${release.waitUntil}</waitUntil>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>2.0.2</version>
-        <relativePath/>
+        <relativePath />
     </parent>
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.0.1</version>
     <name>GlassFish ORB</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB Implementation for Glassfish</description>
@@ -65,7 +65,7 @@
         <connection>scm:git:https://github.com/eclipse-ee4j/orb.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/orb.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/orb</url>
-        <tag>HEAD</tag>
+        <tag>5.0.1</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>5.0.1</version>
+    <version>5.0.2-SNAPSHOT</version>
     <name>GlassFish ORB</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB Implementation for Glassfish</description>
@@ -65,7 +65,7 @@
         <connection>scm:git:https://github.com/eclipse-ee4j/orb.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/orb.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/orb</url>
-        <tag>5.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>5.0.1</version>
     </parent>
 
     <artifactId>rmic</artifactId>


### PR DESCRIPTION
- Finally releasing as 5.0.1, because there are no breaking changes, compared to 5.0.0.
- Old repositories are already removed, so we don't have to disable them
- Deployment is set correctly now, so we don't need most of the original cfg