### PR TITLE
Use a consistent Eclipse license header (end on period)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2025 Contributors to the Eclipse Foundation..
+ *  Copyright (c) 2020, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/csiv2-idl/src/main/java/module-info.java
+++ b/csiv2-idl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/exception-annotation-processor/src/main/java/module-info.java
+++ b/exception-annotation-processor/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/exception-annotation-processor/src/main/java/org/glassfish/corba/annotation/processing/ExceptionWrapperProcessor.java
+++ b/exception-annotation-processor/src/main/java/org/glassfish/corba/annotation/processing/ExceptionWrapperProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/exception-annotation-processor/src/test/java/org/glassfish/corba/annotation/processing/ExceptionWrapperProcessorTestCase.java
+++ b/exception-annotation-processor/src/test/java/org/glassfish/corba/annotation/processing/ExceptionWrapperProcessorTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/idlj/src/main/java/com/sun/tools/corba/ee/idl/Arguments.java
+++ b/idlj/src/main/java/com/sun/tools/corba/ee/idl/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2019 Payara Services Ltd.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1997, 1999 IBM Corp. All rights reserved.

--- a/idlj/src/main/java/module-info.java
+++ b/idlj/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/idlj/src/test/java/com/sun/tools/corba/ee/idl/toJavaPortable/IdljGenerationTest.java
+++ b/idlj/src/test/java/com/sun/tools/corba/ee/idl/toJavaPortable/IdljGenerationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/internal-api/src/main/java/com/sun/corba/ee/spi/logex/stdcorba/StandardLogger.java
+++ b/internal-api/src/main/java/com/sun/corba/ee/spi/logex/stdcorba/StandardLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/internal-api/src/main/java/module-info.java
+++ b/internal-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/internal-api/src/test/java/com/sun/corba/ee/impl/threadpool/ThreadPoolImplTest.java
+++ b/internal-api/src/test/java/com/sun/corba/ee/impl/threadpool/ThreadPoolImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/omgapi/src/main/java/module-info.java
+++ b/omgapi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/ior/WireObjectKeyTemplate.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/ior/WireObjectKeyTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/legacy/connection/SocketFactoryAcceptorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/legacy/connection/SocketFactoryAcceptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAFactory.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/oa/poa/POAImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/oa/toa/TOAFactory.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/oa/toa/TOAFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/orb/ORBImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/presentation/rmi/codegen/CodegenProxyCreator.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/presentation/rmi/codegen/CodegenProxyCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/ServerRequestDispatcherImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/ServerRequestDispatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998-1999 IBM Corp. All rights reserved.
  *

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/resolver/LocalResolverImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/resolver/LocalResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/EventHandlerBase.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/EventHandlerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/transport/TransportManagerImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/transport/TransportManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/transport/IORToSocketInfo.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/transport/IORToSocketInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/main/java/module-info.java
+++ b/orbmain/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/orbmain/src/test/java/com/sun/corba/ee/impl/corba/AnyEqualityTest.java
+++ b/orbmain/src/test/java/com/sun/corba/ee/impl/corba/AnyEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/orbmain/src/test/java/corba/dynamicrmiiiop/testclasses/IDLLeadingUnderscoresTest.java
+++ b/orbmain/src/test/java/corba/dynamicrmiiiop/testclasses/IDLLeadingUnderscoresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/rmic/src/main/java/module-info.java
+++ b/rmic/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
+++ b/rmic/src/main/java/org/glassfish/rmic/asm/AsmClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/rmic/src/test/java/org/glassfish/rmic/asm/AsmClassFactoryTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/asm/AsmClassFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/rmic/src/test/java/org/glassfish/rmic/tools/javac/BatchEnvironmentTest.java
+++ b/rmic/src/test/java/org/glassfish/rmic/tools/javac/BatchEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the


### PR DESCRIPTION
This is largely consmetic, but for consistence use the same Eclipse header line everywhere. Before we had the line ending on a period and without a period.

This PR fixes that to everything with a period.