### PR TITLE
Transfer primitive arrays and Latin-1 strings in bulk in the CDR codec

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/encoding/CDRInputStream_1_0.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/encoding/CDRInputStream_1_0.java
@@ -58,6 +58,7 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.ByteOrder;
 import java.rmi.server.RMIClassLoader;
 import java.security.AccessController;
@@ -453,12 +454,81 @@ public class CDRInputStream_1_0 extends CDRInputStreamBase
             return newEmptyString();
         }
 
-        char[] result = getConvertedChars(len - 1, getCharConverter());
+        CodeSetConversion.BTCConverter converter = getCharConverter();
+
+        Charset singleByteCharset = converter.getSingleByteCharset();
+        if (singleByteCharset != null) {
+            String result = readSingleByteString(len - 1, singleByteCharset);
+
+            // Skip over the 1 byte null
+            read_octet();
+
+            return result;
+        }
+
+        char[] result = getConvertedChars(len - 1, converter);
 
         // Skip over the 1 byte null
         read_octet();
 
-        return new String(result, 0, getCharConverter().getNumChars());
+        return new String(result, 0, converter.getNumChars());
+    }
+
+    /**
+     * Reads a string whose transmission code set is one byte per character,
+     * going straight from the CDR bytes to the String.
+     *
+     * <p>The general path is {@link #getConvertedChars} followed by
+     * {@code new String(char[], int, int)}, which for every string on the
+     * wire runs a CharsetDecoder and allocates three arrays: the decoder's
+     * own CharBuffer, the char[] copied out of it, and then the String's
+     * internal storage. That last copy is not free either - since compact
+     * strings arrived in JDK 9 a Latin-1 String holds a byte[], so the
+     * constructor has to compress the chars back down to the bytes we
+     * started from.
+     *
+     * <p>For a single byte code set none of that is necessary.
+     * {@code new String(bytes, offset, length, ISO_8859_1)} is one array
+     * copy, and for UTF-8 the same constructor reaches HotSpot's
+     * {@code countPositives} intrinsic, which is a vectorised "is this all
+     * ASCII" scan - already faster than anything worth hand writing.
+     *
+     * @param numBytes the string's length, excluding the null terminator
+     * @param charset  the single byte charset to decode with
+     * @return the decoded string
+     */
+    private String readSingleByteString(int numBytes, Charset charset) {
+        if (numBytes == 0) {
+            return newEmptyString();
+        }
+
+        if (byteBuffer.remaining() >= numBytes) {
+            // Wholly inside the current buffer, so it can be read in place.
+            // Note this deliberately does not call read_octet_array: neither
+            // does the equivalent branch of getConvertedChars, and a string
+            // is guaranteed not to straddle a chunk boundary.
+            int position = byteBuffer.position();
+            String result;
+            if (byteBuffer.hasArray()) {
+                result = new String(byteBuffer.array(),
+                        byteBuffer.arrayOffset() + position, numBytes, charset);
+            } else {
+                // A direct buffer cannot be read from without copying, but
+                // one copy plus one String copy still beats a decoder run
+                // plus three.
+                byte[] bytes = new byte[numBytes];
+                byteBuffer.get(bytes, 0, numBytes);
+                result = new String(bytes, charset);
+            }
+            byteBuffer.position(position + numBytes);
+            return result;
+        }
+
+        // Straddles a fragment boundary. Collect the bytes first, exactly as
+        // getConvertedChars does in the same situation.
+        byte[] bytes = new byte[numBytes];
+        read_octet_array(bytes, 0, numBytes);
+        return new String(bytes, charset);
     }
 
     public final String read_string() {
@@ -1598,6 +1668,24 @@ public class CDRInputStream_1_0 extends CDRInputStreamBase
     }
 
     public final void read_char_array(char[] value, int offset, int length) {
+        if (length == 0) {
+            return;
+        }
+
+        CodeSetConversion.BTCConverter converter = getCharConverter();
+        if (converter.getSingleByteCharset() != null) {
+            // Convert the whole array in one pass. Reading it a character at
+            // a time meant one CharsetDecoder invocation, one CharBuffer and
+            // one char[1] per character, so a ten thousand element sequence
+            // produced some twenty thousand short lived objects.
+            char[] converted = getConvertedChars(length, converter);
+            System.arraycopy(converted, 0, value, offset, length);
+            return;
+        }
+
+        // A multi byte char code set is outside what CORBA defines for the
+        // char type, and the byte count would not equal the char count. Keep
+        // the original behaviour rather than guess.
         for(int i=0; i < length; i++) {
             value[i+offset] = read_char();
         }
@@ -1609,9 +1697,47 @@ public class CDRInputStream_1_0 extends CDRInputStreamBase
         }
     }
 
+    /**
+     * Transfers {@code length} elements of {@code elementSize} bytes into a
+     * primitive array using the buffer's bulk operations.
+     *
+     * <p>Reading these arrays an element at a time meant an
+     * {@link #alignAndCheck} - and with it a chunk boundary test - per
+     * element, and denied the JIT any chance to vectorise. The bulk view
+     * operations lower to a memory copy, which is where a SIMD implementation
+     * already exists inside the JDK; there is nothing to gain from writing
+     * one here.
+     *
+     * <p>Correctness rests on the guarantee stated at
+     * {@link #checkBlockLength}: a chunk may end at arbitrary points
+     * <em>except</em> within an array of primitives. So once the first
+     * element is aligned and present, the only boundary that can interrupt
+     * the transfer is the end of the current buffer, which is what the loop
+     * handles - each pass re-aligns and grows exactly as the per element
+     * version did, then moves as many whole elements as the buffer holds.
+     *
+     * @param elementSize the CDR size and alignment of one element
+     * @param length number of elements still to read
+     * @return the number of elements that can be transferred in this pass
+     */
+    private int beginBulkRead(int elementSize, int length) {
+        alignAndCheck(elementSize, elementSize);
+        // alignAndCheck guarantees at least one element is available, so this
+        // is never zero and the caller's loop always makes progress.
+        return Math.min(byteBuffer.remaining() / elementSize, length);
+    }
+
+    private void advance(int elementSize, int count) {
+        byteBuffer.position(byteBuffer.position() + (count * elementSize));
+    }
+
     public final void read_short_array(short[] value, int offset, int length) {
-        for(int i=0; i < length; i++) {
-            value[i+offset] = read_short();
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkRead(2, length - done);
+            byteBuffer.asShortBuffer().get(value, offset + done, batch);
+            advance(2, batch);
+            done += batch;
         }
     }
 
@@ -1620,8 +1746,12 @@ public class CDRInputStream_1_0 extends CDRInputStreamBase
     }
 
     public final void read_long_array(int[] value, int offset, int length) {
-        for(int i=0; i < length; i++) {
-            value[i+offset] = read_long();
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkRead(4, length - done);
+            byteBuffer.asIntBuffer().get(value, offset + done, batch);
+            advance(4, batch);
+            done += batch;
         }
     }
 
@@ -1630,8 +1760,12 @@ public class CDRInputStream_1_0 extends CDRInputStreamBase
     }
 
     public final void read_longlong_array(long[] value, int offset, int length) {
-        for(int i=0; i < length; i++) {
-            value[i+offset] = read_longlong();
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkRead(8, length - done);
+            byteBuffer.asLongBuffer().get(value, offset + done, batch);
+            advance(8, batch);
+            done += batch;
         }
     }
 
@@ -1640,14 +1774,22 @@ public class CDRInputStream_1_0 extends CDRInputStreamBase
     }
 
     public final void read_float_array(float[] value, int offset, int length) {
-        for(int i=0; i < length; i++) {
-            value[i+offset] = read_float();
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkRead(4, length - done);
+            byteBuffer.asFloatBuffer().get(value, offset + done, batch);
+            advance(4, batch);
+            done += batch;
         }
     }
 
     public final void read_double_array(double[] value, int offset, int length) {
-        for(int i=0; i < length; i++) {
-            value[i+offset] = read_double();
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkRead(8, length - done);
+            byteBuffer.asDoubleBuffer().get(value, offset + done, batch);
+            advance(8, batch);
+            done += batch;
         }
     }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/encoding/CDROutputStream_1_0.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/encoding/CDROutputStream_1_0.java
@@ -999,6 +999,33 @@ public class CDROutputStream_1_0 extends CDROutputStreamBase {
         handleSpecialChunkEnd();
     }
 
+    /**
+     * Reserves space for the next run of a primitive array and reports how
+     * many whole elements fit in the current buffer.
+     *
+     * <p>Writing these arrays an element at a time meant an
+     * {@link #alignAndReserve} per element and left the JIT nothing to
+     * vectorise. The bulk put operations lower to a memory copy, which is
+     * where the JDK's own vectorised implementation lives.
+     *
+     * <p>Each pass re-aligns and grows exactly as the per element version
+     * did, so a fragmenting buffer manager still gets to emit a fragment at
+     * the same points; within a pass the elements are contiguous and
+     * self-aligned, and a chunk cannot end inside an array of primitives.
+     *
+     * @param elementSize the CDR size and alignment of one element
+     * @param remaining number of elements still to write
+     * @return the number of elements to transfer in this pass, never zero
+     */
+    private int beginBulkWrite(int elementSize, int remaining) {
+        alignAndReserve(elementSize, elementSize);
+        return Math.min(byteBuffer.remaining() / elementSize, remaining);
+    }
+
+    private void advance(int elementSize, int count) {
+        byteBuffer.position(byteBuffer.position() + (count * elementSize));
+    }
+
     @CdrWrite
     public void write_wchar_array(char[] value, int offset, int length) {
         if (value == null) {
@@ -1025,8 +1052,12 @@ public class CDROutputStream_1_0 extends CDROutputStreamBase {
         // This will only have an effect if we're already chunking
         handleSpecialChunkBegin(computeAlignment(2) + (length * 2));
 
-        for (int i = 0; i < length; i++) {
-            write_short(value[offset + i]);
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkWrite(2, length - done);
+            byteBuffer.asShortBuffer().put(value, offset + done, batch);
+            advance(2, batch);
+            done += batch;
         }
 
         // This will only have an effect if we're already chunking
@@ -1046,8 +1077,12 @@ public class CDROutputStream_1_0 extends CDROutputStreamBase {
         // This will only have an effect if we're already chunking
         handleSpecialChunkBegin(computeAlignment(4) + (length * 4));
 
-        for (int i = 0; i < length; i++) {
-            write_long(value[offset + i]);
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkWrite(4, length - done);
+            byteBuffer.asIntBuffer().put(value, offset + done, batch);
+            advance(4, batch);
+            done += batch;
         }
 
         // This will only have an effect if we're already chunking
@@ -1067,8 +1102,12 @@ public class CDROutputStream_1_0 extends CDROutputStreamBase {
         // This will only have an effect if we're already chunking
         handleSpecialChunkBegin(computeAlignment(8) + (length * 8));
 
-        for (int i = 0; i < length; i++) {
-            write_longlong(value[offset + i]);
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkWrite(8, length - done);
+            byteBuffer.asLongBuffer().put(value, offset + done, batch);
+            advance(8, batch);
+            done += batch;
         }
 
         // This will only have an effect if we're already chunking
@@ -1088,8 +1127,12 @@ public class CDROutputStream_1_0 extends CDROutputStreamBase {
         // This will only have an effect if we're already chunking
         handleSpecialChunkBegin(computeAlignment(4) + (length * 4));
 
-        for (int i = 0; i < length; i++) {
-            write_float(value[offset + i]);
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkWrite(4, length - done);
+            byteBuffer.asFloatBuffer().put(value, offset + done, batch);
+            advance(4, batch);
+            done += batch;
         }
 
         // This will only have an effect if we're already chunking
@@ -1105,8 +1148,12 @@ public class CDROutputStream_1_0 extends CDROutputStreamBase {
         // This will only have an effect if we're already chunking
         handleSpecialChunkBegin(computeAlignment(8) + (length * 8));
 
-        for (int i = 0; i < length; i++) {
-            write_double(value[offset + i]);
+        int done = 0;
+        while (done < length) {
+            int batch = beginBulkWrite(8, length - done);
+            byteBuffer.asDoubleBuffer().put(value, offset + done, batch);
+            advance(8, batch);
+            done += batch;
         }
 
         // This will only have an effect if we're already chunking

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/encoding/CodeSetConversion.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/encoding/CodeSetConversion.java
@@ -120,6 +120,36 @@ public class CodeSetConversion
         public abstract char[] getChars(byte[] bytes, int offset, int length);
         public abstract char[] getChars(ByteBuffer byteBuffer, int offset, int length);
 
+        /**
+         * The Java charset of this converter, but only when every byte value
+         * is a valid character in it - in practice ISO 8859-1, which is the
+         * default char code set and the overwhelming majority of traffic.
+         *
+         * <p>The restriction is about error behaviour, not width. On a code
+         * set where some byte values are illegal - US-ASCII, where anything
+         * above 0x7F is malformed - the CharsetDecoder path throws, and the
+         * ORB turns that into the CORBA exception the specification requires
+         * (formal 00-11-03). {@code new String(bytes, charset)} instead
+         * substitutes U+FFFD and returns normally. Taking the shortcut there
+         * would silently accept corrupt data, so it is offered only where
+         * the two are exactly equivalent.
+         *
+         * <p>A caller that holds the bytes can then build a String directly
+         * with {@code new String(bytes, offset, length, charset)} and skip
+         * this converter altogether. That matters because for a single byte
+         * charset the JDK reduces that constructor to one array copy: since
+         * compact strings arrived in JDK 9 a Latin-1 String <em>is</em> a
+         * byte array, so there is nothing to decode and nothing to compress
+         * afterwards. Going through {@link #getChars} instead costs a
+         * CharsetDecoder run, a CharBuffer, a second char[], and then the
+         * char-to-byte compression that the String constructor has to do to
+         * store the result.
+         *
+         * @return the charset, or null when the code set is not single byte
+         */
+        public Charset getSingleByteCharset() {
+            return null;
+        }
     }
 
     /**
@@ -306,9 +336,34 @@ public class CodeSetConversion
     private class JavaBTCConverter extends BTCConverter {
         protected CharsetDecoder decoder;
         private int resultingNumChars;
+        private Charset singleByteCharset;
 
         public JavaBTCConverter(OSFCodeSetRegistry.Entry codeset) {
             decoder = this.getConverter(codeset.getName());
+            singleByteCharset = resolveSingleByteCharset(codeset);
+        }
+
+        private Charset resolveSingleByteCharset(OSFCodeSetRegistry.Entry codeset) {
+            // Only ISO 8859-1: it is fixed width, one byte per character, and
+            // - the part that matters - it has no illegal byte values, so
+            // decoding it directly cannot differ from decoding it through the
+            // CharsetDecoder. See getSingleByteCharset for why that is the
+            // condition rather than the width.
+            if (codeset != OSFCodeSetRegistry.ISO_8859_1) {
+                return null;
+            }
+            try {
+                return Charset.forName(codeset.getName());
+            } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+                // getConverter above would already have failed on a name this
+                // broken; losing the fast path is not worth failing the stream.
+                return null;
+            }
+        }
+
+        @Override
+        public Charset getSingleByteCharset() {
+            return singleByteCharset;
         }
 
         public final int getNumChars() {

--- a/orbmain/src/test/java/com/sun/corba/ee/impl/encoding/CDRBulkTransferTest.java
+++ b/orbmain/src/test/java/com/sun/corba/ee/impl/encoding/CDRBulkTransferTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License v2.0
+ * w/Classpath exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause OR GPL-2.0 WITH
+ * Classpath-exception-2.0
+ */
+
+package com.sun.corba.ee.impl.encoding;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Covers the cases that distinguish the bulk primitive transfers and the
+ * single byte string path from the element at a time versions they replaced.
+ *
+ * <p>The straightforward cases are already covered by {@link CDRInputTest} and
+ * {@link CDROutputTest} and act as the regression net. What is added here is
+ * what the batching loop introduced and the old loop could not get wrong:
+ * arrays interrupted by a fragment boundary, a destination offset, a byte
+ * order that is not the platform's, and the boundary between the string fast
+ * path and the CharsetDecoder fallback.
+ */
+public class CDRBulkTransferTest extends EncodingTestBase {
+
+    // ---- primitive arrays across a fragment boundary ----------------------
+
+    @Test
+    public void can_read_long_array_acrossFragments() {
+        useV1_2();
+        setMessageBody(0, 0, 0, 1,
+                       0, 0, 0, 2);
+        addFragment(0, 0, 0, 3,
+                    0, 0, 0, 4);
+
+        int[] actual = new int[4];
+        getInputObject().read_long_array(actual, 0, 4);
+        assertArrayEquals(new int[] { 1, 2, 3, 4 }, actual);
+    }
+
+    @Test
+    public void can_read_short_array_acrossFragments() {
+        useV1_2();
+        setMessageBody(0, 1, 0, 2);
+        addFragment(0, 3, 0, 4);
+
+        short[] actual = new short[4];
+        getInputObject().read_short_array(actual, 0, 4);
+        assertArrayEquals(new short[] { 1, 2, 3, 4 }, actual);
+    }
+
+    @Test
+    public void can_read_double_array_acrossFragments() {
+        useV1_2();
+        // The GIOP body starts at stream offset 4, so an 8 byte type needs
+        // four bytes of alignment padding before it.
+        setMessageBody(pad(), pad(), pad(), pad(),
+                       0x3f, 0xd0, 0, 0, 0, 0, 0, 0);
+        addFragment(0x40, 0, 0, 0, 0, 0, 0, 0);
+
+        double[] actual = new double[2];
+        getInputObject().read_double_array(actual, 0, 2);
+        assertEquals(0.25, actual[0], 0.0);
+        assertEquals(2.0, actual[1], 0.0);
+    }
+
+    // ---- offsets and lengths ----------------------------------------------
+
+    @Test
+    public void can_read_long_array_intoAnOffset() {
+        setMessageBody(0, 0, 0, 7,
+                       0, 0, 0, 8);
+
+        int[] actual = new int[5];
+        getInputObject().read_long_array(actual, 2, 2);
+        assertArrayEquals(new int[] { 0, 0, 7, 8, 0 }, actual);
+    }
+
+    @Test
+    public void reading_a_zero_length_array_consumes_nothing() {
+        setMessageBody(0, 0, 0, 9);
+
+        getInputObject().read_long_array(new int[0], 0, 0);
+        assertEquals("the stream must not have advanced", 9, getInputObject().read_long());
+    }
+
+    // ---- byte order --------------------------------------------------------
+
+    @Test
+    public void can_read_long_array_littleEndian() {
+        useLittleEndian();
+        setMessageBody(1, 0, 0, 0,
+                       2, 1, 0, 0);
+
+        int[] actual = new int[2];
+        getInputObject().read_long_array(actual, 0, 2);
+        assertArrayEquals("the bulk view must honour the stream's byte order",
+                new int[] { 1, 0x102 }, actual);
+    }
+
+    @Test
+    public void can_read_short_array_littleEndian() {
+        useLittleEndian();
+        setMessageBody(1, 0, 0x34, 0x12);
+
+        short[] actual = new short[2];
+        getInputObject().read_short_array(actual, 0, 2);
+        assertArrayEquals(new short[] { 1, 0x1234 }, actual);
+    }
+
+    // ---- char arrays --------------------------------------------------------
+
+    @Test
+    public void can_read_char_array() {
+        setCharEncoding(ISO_8859_1);
+        setMessageBody('h', 'e', 'l', 'l', 'o');
+
+        char[] actual = new char[5];
+        getInputObject().read_char_array(actual, 0, 5);
+        assertArrayEquals(new char[] { 'h', 'e', 'l', 'l', 'o' }, actual);
+    }
+
+    @Test
+    public void can_read_char_array_intoAnOffset() {
+        setCharEncoding(ISO_8859_1);
+        setMessageBody('a', 'b');
+
+        char[] actual = new char[4];
+        getInputObject().read_char_array(actual, 1, 2);
+        assertArrayEquals(new char[] { 0, 'a', 'b', 0 }, actual);
+    }
+
+    @Test
+    public void can_read_char_array_acrossFragments() {
+        useV1_2();
+        setCharEncoding(ISO_8859_1);
+        setMessageBody('a', 'b', 'c', 'd');
+        addFragment('e', 'f');
+
+        char[] actual = new char[6];
+        getInputObject().read_char_array(actual, 0, 6);
+        assertArrayEquals(new char[] { 'a', 'b', 'c', 'd', 'e', 'f' }, actual);
+    }
+
+    // ---- strings -------------------------------------------------------------
+
+    @Test
+    public void iso8859_1_stringUsesEveryByteValue() {
+        // 0xE8 is 'e with grave' in Latin-1. It is also the case that would
+        // break if the fast path were extended to US-ASCII, where the same
+        // byte is malformed input and must raise a CORBA exception rather
+        // than quietly become U+FFFD.
+        setCharEncoding(ISO_8859_1);
+        setMessageBody(0, 0, 0, 6, 'c', 'a', 'f', 'f', 0xE8, 0);
+
+        assertEquals("caffè", getInputObject().read_string());
+    }
+
+    @Test
+    public void utf8_stringStillGoesThroughTheDecoder() {
+        // UTF-8 is not eligible for the fast path, so this exercises the
+        // fallback and proves multi byte sequences are unaffected.
+        setCharEncoding(UTF_8);
+        setMessageBody(0, 0, 0, 7, 'c', 'a', 'f', 'f', 0xC3, 0xA8, 0);
+
+        assertEquals("caffè", getInputObject().read_string());
+    }
+
+    @Test
+    public void can_read_empty_string() {
+        setCharEncoding(ISO_8859_1);
+        setMessageBody(0, 0, 0, 1, 0);
+
+        assertEquals("", getInputObject().read_string());
+    }
+
+    @Test
+    public void can_read_string_thenContinueReading() {
+        setCharEncoding(ISO_8859_1);
+        setMessageBody(0, 0, 0, 3, 'h', 'i', 0,
+                       pad(),
+                       0, 0, 0, 42);
+
+        assertEquals("hi", getInputObject().read_string());
+        assertEquals("the null terminator must have been consumed, leaving"
+                        + " only the alignment padding before the next value",
+                42, getInputObject().read_long());
+    }
+
+    // ---- writing --------------------------------------------------------------
+
+    @Test
+    public void can_write_long_array_fromAnOffset() {
+        getOutputObject().write_long_array(new int[] { 9, 9, 1, 2 }, 2, 2);
+
+        expectByteArray(0, 0, 0, 1,
+                        0, 0, 0, 2);
+    }
+
+    @Test
+    public void can_write_short_array() {
+        getOutputObject().write_short_array(new short[] { 1, 0x1234 }, 0, 2);
+
+        expectByteArray(0, 1, 0x12, 0x34);
+    }
+
+    @Test
+    public void can_write_longlong_array() {
+        getOutputObject().write_longlong_array(new long[] { 1, 2 }, 0, 2);
+
+        expectByteArray(PAD, PAD, PAD, PAD,
+                        0, 0, 0, 0, 0, 0, 0, 1,
+                        0, 0, 0, 0, 0, 0, 0, 2);
+    }
+
+    @Test
+    public void writing_a_zero_length_array_writes_nothing() {
+        getOutputObject().write_long_array(new int[0], 0, 0);
+        getOutputObject().write_long(5);
+
+        expectByteArray(0, 0, 0, 5);
+    }
+}


### PR DESCRIPTION
The CDR codec contains no bulk transfer at all. Every primitive array, in both
directions, is a loop over the single element accessor:

```java
public final void read_long_array(int[] value, int offset, int length) {
    for(int i=0; i < length; i++) value[i+offset] = read_long();
}
```

so each element pays an `alignAndCheck` — and with it a chunk boundary test —
and the JIT is given a loop it cannot turn into a memory move.

`read_char_array` was the worst of them. `read_char` is
`getConvertedChars(1, getCharConverter())[0]`, so reading a char array ran the
`CharsetDecoder` once per character and allocated a `CharBuffer` and a `char[1]`
each time; a ten thousand element sequence produced some twenty thousand short
lived objects.

Strings were allocated three times over: the decoder's `CharBuffer`, the
`char[]` copied out of it, and `new String` — which since compact strings
arrived in JDK 9 also has to compress the chars back into the `byte[]` a
Latin-1 String actually holds, which is where the bytes started.

### Approach

The JDK's own bulk operations. No hand written SWAR, on purpose: `ByteBuffer`'s
view buffers and the String constructors already reach HotSpot intrinsics that
are vectorised, and `sun.misc.Unsafe` is terminally deprecated under JEP 471.
The win is in stopping the per element work, not in adding cleverness.

Correctness of the batching loop rests on the guarantee already stated at
`checkBlockLength`: a chunk may end at arbitrary points *except* within an array
of primitives. So once the first element is aligned and present, only the end of
the buffer can interrupt the transfer, and each pass re-aligns and grows exactly
where the per element version would have. A fragmenting buffer manager still
fragments at the same points.

### A deliberate restriction

The string fast path covers ISO 8859-1 only, not single byte code sets
generally. The condition that matters is error behaviour, not width: on US-ASCII
a byte above `0x7F` is malformed input, the `CharsetDecoder` throws, and the ORB
turns that into the CORBA exception the specification requires (formal
00-11-03). `new String` would substitute U+FFFD and return normally, silently
accepting corrupt data. ISO 8859-1 has no illegal byte values, so there the two
are exactly equivalent. UTF-8 keeps going through the decoder for the same
reason, and `read_char_array` takes its single pass conversion only when the
code set is eligible.

### Tests

346 pass, including the 152 existing CDR tests unchanged. The 18 added cover
what the batching loop introduced and the old loop could not get wrong: arrays
interrupted by a fragment boundary, destination offsets, a non-native byte
order, and the boundary between the string fast path and the decoder fallback.